### PR TITLE
Replace default cluster mechanism with "use"

### DIFF
--- a/clusters/bonobo.rb
+++ b/clusters/bonobo.rb
@@ -1,3 +1,5 @@
+require 'clusters/defaults'
+
 ClusterChef.cluster 'bonobo' do
   merge!('defaults')
   setup_role_implications

--- a/clusters/bonobo.rb
+++ b/clusters/bonobo.rb
@@ -1,7 +1,5 @@
-require 'clusters/defaults'
-
 ClusterChef.cluster 'bonobo' do
-  merge!('defaults')
+  use :defaults
   setup_role_implications
 
   recipe                "cluster_chef::dedicated_server_tuning"

--- a/clusters/democassandra.rb
+++ b/clusters/democassandra.rb
@@ -1,3 +1,4 @@
+require 'clusters/defaults'
 
 ClusterChef.cluster 'democassandra' do
   merge!('defaults')

--- a/clusters/democassandra.rb
+++ b/clusters/democassandra.rb
@@ -1,7 +1,5 @@
-require 'clusters/defaults'
-
 ClusterChef.cluster 'democassandra' do
-  merge!('defaults')
+  use :defaults
   setup_role_implications
 
   recipe                "cluster_chef::dedicated_server_tuning"

--- a/clusters/demohadoop.rb
+++ b/clusters/demohadoop.rb
@@ -7,6 +7,7 @@
 # FIXME: should we autogenerate the "foo_cluster" and "foo_bar_facet" roles,
 #        and dispatch those to the chef server?
 # FIXME: EBS volumes?
+require 'clusters/defaults'
 
 ClusterChef.cluster 'demohadoop' do
   merge!('defaults')

--- a/clusters/demohadoop.rb
+++ b/clusters/demohadoop.rb
@@ -7,10 +7,8 @@
 # FIXME: should we autogenerate the "foo_cluster" and "foo_bar_facet" roles,
 #        and dispatch those to the chef server?
 # FIXME: EBS volumes?
-require 'clusters/defaults'
-
 ClusterChef.cluster 'demohadoop' do
-  merge!('defaults')
+  use :defaults
   setup_role_implications
 
   recipe                "cluster_chef::dedicated_server_tuning"

--- a/clusters/demohbase.rb
+++ b/clusters/demohbase.rb
@@ -1,7 +1,5 @@
-require 'clusters/defaults'
-
 ClusterChef.cluster 'demohbase' do
-  merge!('defaults')
+  use :defaults
   setup_role_implications
 
   recipe                "cluster_chef::dedicated_server_tuning"

--- a/clusters/demohbase.rb
+++ b/clusters/demohbase.rb
@@ -1,3 +1,5 @@
+require 'clusters/defaults'
+
 ClusterChef.cluster 'demohbase' do
   merge!('defaults')
   setup_role_implications

--- a/clusters/goldencap.rb
+++ b/clusters/goldencap.rb
@@ -1,7 +1,5 @@
-require 'clusters/defaults'
-
 ClusterChef.cluster 'goldencap' do
-  merge!('defaults')
+  use :defaults
   setup_role_implications
 
   recipe                "hadoop_cluster::system_internals"

--- a/clusters/goldencap.rb
+++ b/clusters/goldencap.rb
@@ -1,3 +1,5 @@
+require 'clusters/defaults'
+
 ClusterChef.cluster 'goldencap' do
   merge!('defaults')
   setup_role_implications

--- a/clusters/yellowhat.rb
+++ b/clusters/yellowhat.rb
@@ -1,7 +1,5 @@
-require 'clusters/defaults'
-
 ClusterChef.cluster 'yellowhat' do
-  merge!('defaults')
+  use :defaults
   setup_role_implications
 
   recipe                "hadoop_cluster::system_internals"

--- a/clusters/yellowhat.rb
+++ b/clusters/yellowhat.rb
@@ -1,3 +1,5 @@
+require 'clusters/defaults'
+
 ClusterChef.cluster 'yellowhat' do
   merge!('defaults')
   setup_role_implications

--- a/clusters/yellowhat_staging.rb
+++ b/clusters/yellowhat_staging.rb
@@ -1,3 +1,5 @@
+require 'clusters/defaults'
+
 ClusterChef.cluster 'yellowhat_staging' do
   merge!('defaults')
   setup_role_implications

--- a/clusters/yellowhat_staging.rb
+++ b/clusters/yellowhat_staging.rb
@@ -1,7 +1,5 @@
-require 'clusters/defaults'
-
 ClusterChef.cluster 'yellowhat_staging' do
-  merge!('defaults')
+  use :defaults
   setup_role_implications
 
   recipe                "hadoop_cluster::system_internals"

--- a/lib/cluster_chef/cloud.rb
+++ b/lib/cluster_chef/cloud.rb
@@ -112,7 +112,7 @@ module ClusterChef
           user_data
         end
       end
-
+      
       def merge! cloud
         @settings = cloud.to_hash.merge @settings
         @settings[:security_groups] = cloud.security_groups.merge(self.security_groups)

--- a/lib/cluster_chef/compute.rb
+++ b/lib/cluster_chef/compute.rb
@@ -131,6 +131,14 @@ module ClusterChef
       self.name
     end
 
+    def use *clusters
+      clusters.each do |cluster|
+        cluster = cluster.to_s
+        require "clusters/#{cluster}"
+        merge! cluster
+      end
+    end
+    
     def merge! other_cluster
       if(other_cluster.is_a?(String)) then other_cluster = ClusterChef.cluster(other_cluster) end
       @settings = other_cluster.to_hash.merge @settings

--- a/lib/cluster_chef/knife/cluster_bootstrap.rb
+++ b/lib/cluster_chef/knife/cluster_bootstrap.rb
@@ -64,7 +64,6 @@ class Chef
         #
         cluster_name, facet_name, server_name = @name_args
         raise "Bootstrap a node with: knife cluster bootstrap CLUSTER_NAME FACET_NAME SERVER_FQDN (options)" if facet_name.blank?
-        require File.expand_path(Chef::Config[:cluster_chef_path]+"/clusters/defaults")
         require File.expand_path(Chef::Config[:cluster_chef_path]+"/clusters/#{cluster_name}")
         facet = Chef::Config[:clusters][cluster_name].facet(facet_name)
         facet.resolve!

--- a/lib/cluster_chef/knife/cluster_launch.rb
+++ b/lib/cluster_chef/knife/cluster_launch.rb
@@ -95,7 +95,6 @@ class Chef
         #
         cluster_name, facet_name = @name_args
         raise "Launch the cluster as: knife cluster launch CLUSTER_NAME FACET_NAME (options)" if facet_name.blank?
-        require File.expand_path(Chef::Config[:cluster_chef_path]+"/clusters/defaults")
         require File.expand_path(Chef::Config[:cluster_chef_path]+"/clusters/#{cluster_name}")
         facet = Chef::Config[:clusters][cluster_name].facet(facet_name)
         facet.resolve!


### PR DESCRIPTION
It is not necessary to build in a requirement that there be a default cluster since any cluster definition can require and merge any other. 
