### PR TITLE
Change dry_run param to dry-run to be consistent with param style

### DIFF
--- a/lib/cluster_chef/knife/cluster_launch.rb
+++ b/lib/cluster_chef/knife/cluster_launch.rb
@@ -29,7 +29,7 @@ class Chef
       attr_accessor :initial_sleep_delay
 
       option :dry_run,
-        :long => "--dry_run",
+        :long => "--dry-run",
         :description => "Don't really run, just use mock calls"
 
       option :bootstrap,

--- a/lib/cluster_chef/knife/cluster_show.rb
+++ b/lib/cluster_chef/knife/cluster_show.rb
@@ -29,7 +29,7 @@ class Chef
       attr_accessor :initial_sleep_delay
 
       option :dry_run,
-        :long => "--dry_run",
+        :long => "--dry-run",
         :description => "Don't really run, just use mock calls"
 
       def h


### PR DESCRIPTION
Changed dry_run to dry-run since all other params are dasherized instead of underscored.
