### PR TITLE
Allow default cluster/facet roles to be overridden

### DIFF
--- a/lib/cluster_chef/compute.rb
+++ b/lib/cluster_chef/compute.rb
@@ -121,7 +121,7 @@ module ClusterChef
       super(clname)
       @facets = {}
       chef_attributes  :cluster_name => clname
-      cluster_role clname
+      cluster_role "#{clname}_cluster"
     end
 
     def facet facet_name, &block

--- a/lib/cluster_chef/compute.rb
+++ b/lib/cluster_chef/compute.rb
@@ -115,10 +115,13 @@ module ClusterChef
   #
   class Cluster < ClusterChef::ComputeBuilder
     attr_reader :facets
+    has_keys :cluster_role
+    
     def initialize clname
       super(clname)
       @facets = {}
       chef_attributes  :cluster_name => clname
+      cluster_role clname
     end
 
     def facet facet_name, &block
@@ -143,15 +146,15 @@ module ClusterChef
 
   class Facet < ClusterChef::ComputeBuilder
     attr_reader :cluster
-    has_keys :chef_node_name, :instances, :facet_index
+    has_keys :chef_node_name, :instances, :facet_index, :facet_role
 
     def initialize cluster, facet_name
       super(facet_name)
       @cluster = cluster
       chef_attributes :cluster_role       => facet_name # backwards compatibility
       chef_attributes :facet_name         => facet_name
-      role             "#{@cluster.name}_cluster"
-      role             "#{@cluster.name}_#{facet_name}"
+      facet_role      "#{@cluster.name}_#{facet_name}"
+
       unless facet_index.blank?
         chef_node_name "#{@cluster.name}-#{facet_name}-#{facet_index}"
         chef_attributes :node_name          => chef_node_name
@@ -174,6 +177,10 @@ module ClusterChef
       cloud.keypair           clname if cloud.keypair.blank?
       cloud.security_group    clname do authorize_group clname end
       cloud.security_group "#{clname}-#{self.name}"
+      
+      role cluster.cluster_role if cluster.cluster_role
+      role self.facet_role if self.facet_role
+      
       @settings[:run_list]        = @cluster.run_list + self.run_list
       @settings[:chef_attributes] = @cluster.chef_attributes.merge(self.chef_attributes)
       chef_attributes :run_list => run_list


### PR DESCRIPTION
Currently each created node gets two default roles named "#{cluster_name}" and "#{cluster_name}_facet". This is a great convention but users should have the option to do something different.

This patch introduces the cluster_role and facet_role options to allow custom roles to be used or to disable the role addition by setting cluster/facet_role to false.
