### PR TITLE
rake fails unless ruby_debug is added to the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,4 +23,5 @@ group :development do
   # only interesting for coverage testing
   gem 'rcov',      ">= 0.9.9"
   gem 'watchr'
+  gem 'ruby-debug'
 end


### PR DESCRIPTION
The initial problem:

```
cluster_chef$ bundle exec rake -T
rake aborted!
no such file to load -- ruby-debug
```
