### PR TITLE
Add oneric support

### DIFF
--- a/lib/chef/knife/bootstrap/ubuntu11.10-cluster_chef.erb
+++ b/lib/chef/knife/bootstrap/ubuntu11.10-cluster_chef.erb
@@ -1,0 +1,119 @@
+bash -c '
+
+# This is the ubuntu-10.04-cluster_chef script from infochimps, which
+# is based on the ubuntu-10.04-gems script from opscode, but it
+# * installs ruby 1.9.2, not 1.8.7 using the system ruby
+# * upgrades rubygems rather than installing from source
+# * pushes the node identity into the first-boot.json
+# * installs the chef-client service and kicks off the first run of chef
+
+<%= (@config[:verbosity].to_i > 1 ? 'set -v' : '') %>
+
+mkdir -p /tmp/knife-bootstrap ; chmod 700 /tmp/knife-bootstrap 
+cd /tmp/knife-bootstrap
+
+<%= "export http_proxy=\"#{knife_config[:bootstrap_proxy]}\"" if knife_config[:bootstrap_proxy] -%>
+eval `cat /etc/lsb-release `
+export DEBIAN_FRONTEND=noninteractive
+
+if [ ! -f /usr/bin/chef-client ]; then
+echo -e "`date` \n\n**** \n**** apt update:\n****\n"
+apt-get    update
+apt-get -y upgrade
+
+echo -e "`date` \n\n**** \n**** Installing base packages:\n****\n"
+apt-get install -y build-essential wget ruby1.9.1 ruby1.9.1-dev runit runit-services zlib1g-dev libssl-dev openssl libcurl4-openssl-dev libreadline6-dev libyaml-dev
+
+if ruby -e "exit(%x{gem --version} < \"1.6.2\" ? 0 : -1 )" ; then
+  echo -e "`date` \n\n**** \n**** Updating rubygems:\n****\n"
+  gem install --no-rdoc --no-ri rubygems-update --version=1.6.2
+  update_rubygems --version=1.6.2
+fi
+
+echo -e "`date` \n\n**** \n**** Installing chef:\n****\n"
+gem install ohai --no-rdoc --no-ri
+gem install chef --no-rdoc --no-ri <%= bootstrap_version_string %>
+gem install      --no-rdoc --no-ri extlib json ruby-shadow right_aws
+
+else # no chef-client
+echo -e "`date` \n\n**** \n**** Chef is present -- skipping apt/ruby/chef installation\n****\n"
+fi 
+
+# fix a bug in chef that prevents debugging template errors
+bad_template_file='/usr/lib/ruby/gems/1.9.2-p290/gems/chef-0.10.4/lib/chef/mixin/template.rb'
+if  echo "0505c482b8b0b333ac71bbc8a1795d19  $bad_template_file" | md5sum -c - 2>/dev/null ; then
+  curl https://github.com/mrflip/chef/commit/655a1967253a8759afb54f30b818bbcb7c309198.patch | sudo patch $bad_template_file
+fi
+
+echo -e "`date` \n\n**** \n**** Knifing in the chef client config files:\n****\n"
+mkdir -p /etc/chef
+
+<%- if @config[:client_key] %>
+(
+cat <<'EOP'
+<%= @config[:client_key] %>
+EOP
+) > /tmp/knife-bootstrap/client.pem
+awk NF /tmp/knife-bootstrap/client.pem > /etc/chef/client.pem
+<%- else %>
+(
+cat <<'EOP'
+<%= validation_key %>
+EOP
+) > /tmp/knife-bootstrap/validation.pem
+awk NF /tmp/knife-bootstrap/validation.pem > /etc/chef/validation.pem
+<%- end %>
+
+echo -e "`date` \n\n**** \n**** Nuking our temp files:\n****\n"
+
+cd /tmp
+# rm -rf /tmp/knife-bootstrap
+
+echo -e "`date` \n\n**** \n**** Creating chef client script:\n****\n"
+
+(
+cat <<'EOP'
+<%= config_content %>
+<%= @config[:node].chef_client_script_content %>
+EOP
+) > /etc/chef/client.rb
+
+(
+cat <<'EOP'
+<%= { "run_list" => @run_list, "cluster_name" => @config[:node].cluster_name, "facet_name" => @config[:node].facet_name, "facet_index" => @config[:node].facet_index }.to_json %>
+EOP
+) > /etc/chef/first-boot.json
+
+echo -e "`date` \n\n**** \n**** Adding chef client runit scripts:\n****\n"
+service chef-client stop >/dev/null 2>&1 ; sleep 1 ; killall chef-client 2>/dev/null ; true
+mkdir -p /var/log/chef /var/chef /etc/service /etc/sv/chef-client/{log/main,supervise} 
+cat > /etc/sv/chef-client/log/run <<EOF
+#!/bin/bash
+exec svlogd -tt ./main
+EOF
+cat > /etc/sv/chef-client/run <<EOF
+#!/bin/bash
+exec 2>&1
+exec /usr/bin/env chef-client -i 43200 -s 20 -L /var/log/chef/client.log
+EOF
+chmod +x  /etc/sv/chef-client/log/run /etc/sv/chef-client/run
+ln -nfs /usr/bin/sv /etc/init.d/chef-client
+
+service chef-client stop ; true
+
+<%- if (@config[:bootstrap_runs_chef_client].to_s == 'true') || (@chef_config.knife[:bootstrap_runs_chef_client].to_s == 'true') %>
+echo -e "`date` \n\n**** \n**** First run of chef:\n****\n"
+set -e
+<%= start_chef %>
+set +e
+<%- end %>
+
+echo -e "`date` \n\n**** \n**** Cleanup:\n****\n"
+updatedb
+
+echo -e "`date` \n\n**** \n**** Enabling chef client service:\n****\n"
+ln -nfs /etc/sv/chef-client /etc/service/chef-client
+service chef-client start
+
+echo -e "`date` \n\n**** \n**** Cluster Chef client bootstrap complete\n****\n"
+'

--- a/lib/chef/knife/bootstrap/ubuntu11.10-cluster_chef.erb
+++ b/lib/chef/knife/bootstrap/ubuntu11.10-cluster_chef.erb
@@ -43,7 +43,7 @@ echo -e "`date` \n\n**** \n**** Chef is present -- skipping apt/ruby/chef instal
 fi 
 
 # fix a bug in chef that prevents debugging template errors
-bad_template_file='/usr/lib/ruby/gems/1.9.2-p290/gems/chef-0.10.4/lib/chef/mixin/template.rb'
+bad_template_file='/usr/lib/ruby/gems/1.9.1/gems/chef-0.10.4/lib/chef/mixin/template.rb'
 if  echo "0505c482b8b0b333ac71bbc8a1795d19  $bad_template_file" | md5sum -c - 2>/dev/null ; then
   curl https://github.com/mrflip/chef/commit/655a1967253a8759afb54f30b818bbcb7c309198.patch | sudo patch $bad_template_file
 fi

--- a/lib/chef/knife/bootstrap/ubuntu11.10-cluster_chef.erb
+++ b/lib/chef/knife/bootstrap/ubuntu11.10-cluster_chef.erb
@@ -25,7 +25,7 @@ apt-get    update
 apt-get -y upgrade
 
 echo -e "`date` \n\n**** \n**** Installing base packages:\n****\n"
-apt-get install -y build-essential wget ruby1.9.1 ruby1.9.1-dev runit runit-services zlib1g-dev libssl-dev openssl libcurl4-openssl-dev libreadline6-dev libyaml-dev
+apt-get install -y build-essential wget ruby1.9.1 ruby1.9.1-dev runit zlib1g-dev libssl-dev openssl libcurl4-openssl-dev libreadline6-dev libyaml-dev
 
 if ruby -e "exit(%x{gem --version} < \"1.6.2\" ? 0 : -1 )" ; then
   echo -e "`date` \n\n**** \n**** Updating rubygems:\n****\n"

--- a/lib/chef/knife/bootstrap/ubuntu11.10-cluster_chef.erb
+++ b/lib/chef/knife/bootstrap/ubuntu11.10-cluster_chef.erb
@@ -7,9 +7,12 @@ bash -c '
 # * pushes the node identity into the first-boot.json
 # * installs the chef-client service and kicks off the first run of chef
 
+set -e
+
 <%= (@config[:verbosity].to_i > 1 ? 'set -v' : '') %>
 
-mkdir -p /tmp/knife-bootstrap ; chmod 700 /tmp/knife-bootstrap 
+mkdir -p /tmp/knife-bootstrap
+chmod 700 /tmp/knife-bootstrap 
 cd /tmp/knife-bootstrap
 
 <%= "export http_proxy=\"#{knife_config[:bootstrap_proxy]}\"" if knife_config[:bootstrap_proxy] -%>
@@ -85,7 +88,7 @@ EOP
 ) > /etc/chef/first-boot.json
 
 echo -e "`date` \n\n**** \n**** Adding chef client runit scripts:\n****\n"
-service chef-client stop >/dev/null 2>&1 ; sleep 1 ; killall chef-client 2>/dev/null ; true
+(service chef-client stop >/dev/null 2>&1 ; sleep 1 ; killall chef-client 2>/dev/null) || true
 mkdir -p /var/log/chef /var/chef /etc/service /etc/sv/chef-client/{log/main,supervise} 
 cat > /etc/sv/chef-client/log/run <<EOF
 #!/bin/bash
@@ -99,7 +102,7 @@ EOF
 chmod +x  /etc/sv/chef-client/log/run /etc/sv/chef-client/run
 ln -nfs /usr/bin/sv /etc/init.d/chef-client
 
-service chef-client stop ; true
+service chef-client stop || true
 
 <%- if (@config[:bootstrap_runs_chef_client].to_s == 'true') || (@chef_config.knife[:bootstrap_runs_chef_client].to_s == 'true') %>
 echo -e "`date` \n\n**** \n**** First run of chef:\n****\n"
@@ -116,4 +119,4 @@ ln -nfs /etc/sv/chef-client /etc/service/chef-client
 service chef-client start
 
 echo -e "`date` \n\n**** \n**** Cluster Chef client bootstrap complete\n****\n"
-'
+' || echo "Chef bootstrap failed!"

--- a/lib/cluster_chef/cloud.rb
+++ b/lib/cluster_chef/cloud.rb
@@ -354,6 +354,39 @@ module ClusterChef
           %w[ us-west-1            32-bit  instance        natty                          ] => { :image_id => 'ami-e95f03ac', :ssh_user => 'ubuntu', :bootstrap_distro => "ubuntu10.04-gems", },
           %w[ us-west-1            64-bit  ebs             natty                          ] => { :image_id => 'ami-4d580408', :ssh_user => 'ubuntu', :bootstrap_distro => "ubuntu10.04-gems", },
           %w[ us-west-1            64-bit  instance        natty                          ] => { :image_id => 'ami-a15f03e4', :ssh_user => 'ubuntu', :bootstrap_distro => "ubuntu10.04-gems", },
+
+          #
+          # Oneric (Ubuntu 11.10)
+          #
+          %w[ ap-northeast-1       32-bit  ebs             oneric                         ] => { :image_id => 'ami-2e90242f', :ssh_user => 'ubuntu', :bootstrap_distro => "ubuntu10.04-gems", },
+          %w[ ap-northeast-1       32-bit  instance        oneric                         ] => { :image_id => 'ami-e49723e5', :ssh_user => 'ubuntu', :bootstrap_distro => "ubuntu10.04-gems", },
+          %w[ ap-northeast-1       64-bit  ebs             oneric                         ] => { :image_id => 'ami-30902431', :ssh_user => 'ubuntu', :bootstrap_distro => "ubuntu10.04-gems", },
+          %w[ ap-northeast-1       64-bit  instance        oneric                         ] => { :image_id => 'ami-fa9723fb', :ssh_user => 'ubuntu', :bootstrap_distro => "ubuntu10.04-gems", },
+          #
+          %w[ ap-southeast-1       32-bit  ebs             oneric                         ] => { :image_id => 'ami-76057f24', :ssh_user => 'ubuntu', :bootstrap_distro => "ubuntu10.04-gems", },
+          %w[ ap-southeast-1       32-bit  instance        oneric                         ] => { :image_id => 'ami-82047ed0', :ssh_user => 'ubuntu', :bootstrap_distro => "ubuntu10.04-gems", },
+          %w[ ap-southeast-1       64-bit  ebs             oneric                         ] => { :image_id => 'ami-7a057f28', :ssh_user => 'ubuntu', :bootstrap_distro => "ubuntu10.04-gems", },
+          %w[ ap-southeast-1       64-bit  instance        oneric                         ] => { :image_id => 'ami-54057f06', :ssh_user => 'ubuntu', :bootstrap_distro => "ubuntu10.04-gems", },
+          #
+          %w[ eu-west-1            32-bit  ebs             oneric                         ] => { :image_id => 'ami-65b28011', :ssh_user => 'ubuntu', :bootstrap_distro => "ubuntu10.04-gems", },
+          %w[ eu-west-1            32-bit  instance        oneric                         ] => { :image_id => 'ami-dfcdffab', :ssh_user => 'ubuntu', :bootstrap_distro => "ubuntu10.04-gems", },
+          %w[ eu-west-1            64-bit  ebs             oneric                         ] => { :image_id => 'ami-61b28015', :ssh_user => 'ubuntu', :bootstrap_distro => "ubuntu10.04-gems", },
+          %w[ eu-west-1            64-bit  instance        oneric                         ] => { :image_id => 'ami-75b28001', :ssh_user => 'ubuntu', :bootstrap_distro => "ubuntu10.04-gems", },
+          #
+          %w[ us-east-1            32-bit  ebs             oneric                         ] => { :image_id => 'ami-a7f539ce', :ssh_user => 'ubuntu', :bootstrap_distro => "ubuntu10.04-gems", },
+          %w[ us-east-1            32-bit  instance        oneric                         ] => { :image_id => 'ami-29f43840', :ssh_user => 'ubuntu', :bootstrap_distro => "ubuntu10.04-gems", },
+          %w[ us-east-1            64-bit  ebs             oneric                         ] => { :image_id => 'ami-bbf539d2', :ssh_user => 'ubuntu', :bootstrap_distro => "ubuntu10.04-gems", },
+          %w[ us-east-1            64-bit  instance        oneric                         ] => { :image_id => 'ami-21f53948', :ssh_user => 'ubuntu', :bootstrap_distro => "ubuntu10.04-gems", },
+          #
+          %w[ us-west-1            32-bit  ebs             oneric                         ] => { :image_id => 'ami-79772b3c', :ssh_user => 'ubuntu', :bootstrap_distro => "ubuntu10.04-gems", },
+          %w[ us-west-1            32-bit  instance        oneric                         ] => { :image_id => 'ami-a7762ae2', :ssh_user => 'ubuntu', :bootstrap_distro => "ubuntu10.04-gems", },
+          %w[ us-west-1            64-bit  ebs             oneric                         ] => { :image_id => 'ami-7b772b3e', :ssh_user => 'ubuntu', :bootstrap_distro => "ubuntu10.04-gems", },
+          %w[ us-west-1            64-bit  instance        oneric                         ] => { :image_id => 'ami-4b772b0e', :ssh_user => 'ubuntu', :bootstrap_distro => "ubuntu10.04-gems", },
+          #
+          %w[ us-west-2            32-bit  ebs             oneric                         ] => { :image_id => 'ami-20f97410', :ssh_user => 'ubuntu', :bootstrap_distro => "ubuntu10.04-gems", },
+          %w[ us-west-2            32-bit  instance        oneric                         ] => { :image_id => 'ami-52f67b62', :ssh_user => 'ubuntu', :bootstrap_distro => "ubuntu10.04-gems", },
+          %w[ us-west-2            64-bit  ebs             oneric                         ] => { :image_id => 'ami-2af9741a', :ssh_user => 'ubuntu', :bootstrap_distro => "ubuntu10.04-gems", },
+          %w[ us-west-2            64-bit  instance        oneric                         ] => { :image_id => 'ami-56f67b66', :ssh_user => 'ubuntu', :bootstrap_distro => "ubuntu10.04-gems", },
         })
     end
 


### PR DESCRIPTION
This is twofold.  One, I wanted to run oneric images, so this is the current set for all the various AWS regions.  Two, the reason I wanted to run oneric images is that 1.9.2p290 is the system Ruby 1.9.1 (I know, horrible name), and that way I didn't have to burn compute time recompiling ruby, an especially fun thing to do on micros.  Accordingly I redid the boot script and made it fail more obviously when it doesn't work.
