### PR TITLE
Make vagrant ip settings work from knife-org.rb

### DIFF
--- a/lib/chef/knife/cluster_vagrant.rb
+++ b/lib/chef/knife/cluster_vagrant.rb
@@ -63,7 +63,7 @@ class Chef
 
       def run
         # The subnet for this world
-        Chef::Config.host_network_blk   ||= '33.33.33'
+        Chef::Config.host_network_base   ||= '33.33.33'
         # Location that cookbooks, roles, etc will be mounted on vm
         # set to false to skip
         Chef::Config.homebase_on_vm_dir "/homebase" if Chef::Config.homebase_on_vm_dir.nil?

--- a/lib/chef/knife/vagrant/skeleton_vagrantfile.rb
+++ b/lib/chef/knife/vagrant/skeleton_vagrantfile.rb
@@ -33,7 +33,7 @@ Vagrant::Config.run do |config|
   #
 
   def ip_for(svr)
-    "#{Chef::Config.host_network_blk}.#{30 + svr.facet_index}"
+    "#{Chef::Config.host_network_base}.#{(Chef::Config.host_network_ip_mapping[svr.facet_name] || 30) + svr.facet_index}"
   end
 
   # FIXME: things like this should be imputed by the `cloud` statement


### PR DESCRIPTION
Still very new to ironfan, so please let me know if this needs adjusting!

---

use host_network_base in cluster_vagrant.rb to use the definable value
in knife.org

fixup ip_for method to look up the correct ip mapping for the facet
being launched.
