### PR TITLE
node attribues should be 'normal', not 'override' -- they don't show up as printed on the node otherwise

### DIFF
--- a/lib/ironfan/chef_layer.rb
+++ b/lib/ironfan/chef_layer.rb
@@ -192,7 +192,6 @@ module Ironfan
       end
     end
 
-
     def sync_volume_attributes
       composite_volumes.each do |vol_name, vol|
         chef_node.normal[:volumes] ||= Mash.new
@@ -203,11 +202,11 @@ module Ironfan
     def set_chef_node_attributes
       step("  setting node runlist and essential attributes")
       @chef_node.run_list = Chef::RunList.new(*@settings[:run_list])
-      @chef_node.normal[:organization]   = organization if organization
-      @chef_node.normal[:permanent]      = cloud.permanent if cloud.permanent
-      @chef_node.override[:cluster_name] = cluster_name
-      @chef_node.override[:facet_name]   = facet_name
-      @chef_node.override[:facet_index]  = facet_index
+      @chef_node.normal[:organization] = organization if organization
+      @chef_node.normal[:permanent]    = cloud.permanent if cloud.permanent
+      @chef_node.normal[:cluster_name] = cluster_name
+      @chef_node.normal[:facet_name]   = facet_name
+      @chef_node.normal[:facet_index]  = facet_index
     end
 
     def set_chef_node_environment


### PR DESCRIPTION
When ironfan syncs the node to the server, it should set the node attributes using 'nornal', not 'override'. 

Please note: though I believe this is the correct behavior I don't know whether **currently-existing nodes will have a remnant 'override' attribute**. All but one of attributes in question are immutable on a node -- organization, cluster_name, facet_name and facet_index -- but `permanent` is not.
