### PR TITLE
Add encrypted_data_bag_secret support to ironfan templates

### DIFF
--- a/lib/chef/knife/bootstrap/centos6.2-ironfan.erb
+++ b/lib/chef/knife/bootstrap/centos6.2-ironfan.erb
@@ -89,6 +89,16 @@ EOP
 awk NF /tmp/knife-bootstrap/validation.pem > /etc/chef/validation.pem
 <%- end %>
 
+<% if @chef_config[:encrypted_data_bag_secret] -%>
+(
+cat <<'EOP'
+<%= encrypted_data_bag_secret %>
+EOP
+) > /tmp/encrypted_data_bag_secret
+awk NF /tmp/encrypted_data_bag_secret > /etc/chef/encrypted_data_bag_secret
+rm /tmp/encrypted_data_bag_secret
+<% end -%>
+
 echo -e "`date` \n\n**** \n**** Nuking our temp files:\n****\n"
 
 cd /tmp

--- a/lib/chef/knife/bootstrap/ubuntu10.04-ironfan.erb
+++ b/lib/chef/knife/bootstrap/ubuntu10.04-ironfan.erb
@@ -107,6 +107,16 @@ EOP
 awk NF /tmp/knife-bootstrap/validation.pem > /etc/chef/validation.pem
 <%- end %>
 
+<% if @chef_config[:encrypted_data_bag_secret] -%>
+(
+cat <<'EOP'
+<%= encrypted_data_bag_secret %>
+EOP
+) > /tmp/encrypted_data_bag_secret
+awk NF /tmp/encrypted_data_bag_secret > /etc/chef/encrypted_data_bag_secret
+rm /tmp/encrypted_data_bag_secret
+<% end -%>
+
 echo -e "`date` \n\n**** \n**** Nuking our temp files:\n****\n"
 
 cd /tmp

--- a/lib/chef/knife/bootstrap/ubuntu11.10-ironfan.erb
+++ b/lib/chef/knife/bootstrap/ubuntu11.10-ironfan.erb
@@ -95,6 +95,16 @@ EOP
 awk NF /tmp/knife-bootstrap/validation.pem > /etc/chef/validation.pem
 <%- end %>
 
+<% if @chef_config[:encrypted_data_bag_secret] -%>
+(
+cat <<'EOP'
+<%= encrypted_data_bag_secret %>
+EOP
+) > /tmp/encrypted_data_bag_secret
+awk NF /tmp/encrypted_data_bag_secret > /etc/chef/encrypted_data_bag_secret
+rm /tmp/encrypted_data_bag_secret
+<% end -%>
+
 echo -e "`date` \n\n**** \n**** Nuking our temp files:\n****\n"
 
 cd /tmp


### PR DESCRIPTION
The current ironfan templates don't have the logic to copy the encrypted_data_bag_secret key to the target nodes. This key is needed to access encrypted data bags.

This change duplicates the encrypted_data_bag_secret logic from the standard chef templates.
