### PR TITLE
Fix for launches across AWS Regions

### DIFF
--- a/lib/chef/knife/cluster_launch.rb
+++ b/lib/chef/knife/cluster_launch.rb
@@ -136,6 +136,9 @@ class Chef
       rescue Errno::ECONNREFUSED
         sleep 2
         false
+      rescue Errno::EHOSTUNREACH
+        sleep 2
+        false
       ensure
         tcp_socket && tcp_socket.close
       end


### PR DESCRIPTION
When I run ironfan-homebase on a us-east host and launch a cluster in us-west, I get a Errno::ECONNREFUSED, although the host is reachable a few moments later.  

This is probably due to some amazon-specific inter-zone routing quirks.  I do not see this issue when I run my knife commands on a host outside of the cloud.

A similar fix exists in the knife-ec2 plugin, where this code appears to have come from.

This is a re-submit of my pull request that has been cleaned up
