### PR TITLE
Ensure servers in ServerSlice are flattened, so :select and :find call to a ServerSlice object returns a Server not a ServerSlice

### DIFF
--- a/lib/ironfan/cluster.rb
+++ b/lib/ironfan/cluster.rb
@@ -83,7 +83,7 @@ module Ironfan
     #
     # @return [Ironfan::ServerSlice] the requested slice
     def slice facet_name=nil, slice_indexes=nil
-      return Ironfan::ServerSlice.new(self, self.servers) if facet_name.nil?
+      return servers if facet_name.nil?
       find_facet(facet_name).slice(slice_indexes)
     end
 


### PR DESCRIPTION
This is a bug fix to ensure servers in ServerSlice are flattened, so :select and :find call to a ServerSlice object returns a Server not a ServerSlice
