### PR TITLE
Volume definitions fail due to changes within machine.rb

### DIFF
--- a/lib/ironfan/dsl/volume.rb
+++ b/lib/ironfan/dsl/volume.rb
@@ -29,7 +29,7 @@ module Ironfan
         :blank_xfs       => 'snap-d9c1edb1',
       })
 
-      def snapshot_id(id)
+      def snapshot_id(*)
         Chef::Log.warn("CODE SMELL: EBS specific information in Dsl::Volume::VOLUME_IDS")
         super || VOLUME_IDS[snapshot_name]
       end


### PR DESCRIPTION
This appears to be a deprecated method for now magic fields. It's remove appears to have fixed my volume definitions but I cannot guarantee this segment was required, nor do I have a test suite created.
