### PR TITLE
Like any good hitman, knife cluster kill should 'take care of' errant clients.

### DIFF
--- a/lib/chef/knife/cluster_launch.rb
+++ b/lib/chef/knife/cluster_launch.rb
@@ -79,10 +79,11 @@ class Chef
         ui.info("")
         section("Launching computers", :green)
         display(target)
-        target.launch
+        launched = target.launch
 
         # As each server finishes, configure it
-        Ironfan.parallel(target.values) do |computer|
+        Ironfan.parallel(launched) do |computer|
+          if (computer.is_a?(Exception)) then ui.warn "Error launching #{computer.inspect}; skipping after-launch tasks."; next; end
           perform_after_launch_tasks(computer)
         end
         # progressbar_for_threads(watcher_threads)

--- a/lib/chef/knife/cluster_show.rb
+++ b/lib/chef/knife/cluster_show.rb
@@ -42,19 +42,48 @@ class Chef
         # Load the cluster/facet/slice/whatever
         target = get_slice(* @name_args)
 
+        dump_command_config
+        dump_chef_config
         #
-        # Dump entire contents of objects if -VV flag given
-        #
-        if config[:verbosity] >= 2
-          target.each do |computer|
-            Chef::Log.debug( "Computer #{computer.name}: #{JSON.pretty_generate(computer.to_wire)}" )
-          end
+        target.each do |computer|
+          dump_computer(computer)
         end
 
         # Display same
         display(target)
-
       end
+
+    protected
+
+      def dump_computer(computer)
+        with_verbosity 1 do
+          dump("Computer #{computer.name} (#{computer.class})", computer.to_wire)
+        end
+      end
+
+      def dump_command_config
+        with_verbosity 2 do
+          Chef::Log.info( ["", "*"*50, "", "Command Config", ""].join("\n") )
+          dump("Command config", self.config)
+        end
+      end
+
+      def dump_chef_config
+        with_verbosity 2 do
+          chef_config_hash = Hash[Chef::Config.keys.map{|key| [key, Chef::Config[key]]}]
+          dump("Chef Config", chef_config_hash)
+        end
+      end
+
+      def dump(title, hsh)
+        Chef::Log.info( ["", "*"*50, "", "#{title}: ", ""].join("\n") )
+        Chef::Log.info( MultiJson.dump(hsh, pretty: true ) )
+      end
+
+      def with_verbosity(num)
+        yield if config[:verbosity] >= num
+      end
+
     end
   end
 end

--- a/lib/chef/knife/ironfan_knife_common.rb
+++ b/lib/chef/knife/ironfan_knife_common.rb
@@ -37,9 +37,13 @@ module Ironfan
         ui.warn("Please specify server slices joined by dashes and not separate args:\n\n  knife cluster #{sub_command} #{slice_string}\n\n")
       end
       cluster_name, facet_name, slice_indexes = slice_string.split(/[\s\-]/, 3)
-      ui.info("Inventorying servers in #{predicate_str(cluster_name, facet_name, slice_indexes)}")
-      cluster = Ironfan.load_cluster(cluster_name)
+      desc = predicate_str(cluster_name, facet_name, slice_indexes)
+      #
+      ui.info("Inventorying servers in #{desc}")
+      cluster   = Ironfan.load_cluster(cluster_name)
       computers =  broker.discover! cluster
+      Chef::Log.info("Inventoried #{computers.size} computers")
+      #
       computers.slice(facet_name, slice_indexes)
     end
 
@@ -80,7 +84,7 @@ module Ironfan
     def display(target, display_style=nil, &block)
       display_style ||= (config[:verbosity] == 0 ? :default : :expanded)
 #       target.display(ui, display_style, &block)
-      broker.display(target,display_style)
+      broker.display(target, display_style)
     end
 
     #

--- a/lib/ironfan.rb
+++ b/lib/ironfan.rb
@@ -25,12 +25,18 @@ module Ironfan
   def self.chef_config()    @chef_config      ; end
 
   # execute against multiple targets in parallel
-  def self.parallel(targets,options={})
+  def self.parallel(targets)
     raise 'missing block' unless block_given?
-    [targets].flatten.map do |target|
+    results = []
+    [targets].flatten.each_with_index.map do |target, idx|
       sleep(0.1) # avoid hammering with simultaneous requests
-      Thread.new(target) {|target| yield target }
+      Thread.new(target) do |target|
+        results[idx] = safely(target.inspect) do
+          yield target
+        end
+      end
     end.each(&:join) # wait for all the blocks to return
+    results
   end
 
   #
@@ -120,13 +126,15 @@ module Ironfan
   #     Ironfan.fog_connection.associate_address(self.fog_server.id, address)
   #   end
   #
-  def self.safely
+  def self.safely(info="")
     begin
       yield
-    rescue StandardError => boom
-      ui.info( boom )
-      Chef::Log.error( boom )
-      Chef::Log.error( boom.backtrace.join("\n") )
+    rescue StandardError => err
+      ui.warn("Error running #{info}:")
+      ui.warn(err)
+      Chef::Log.error( err )
+      Chef::Log.error( err.backtrace.join("\n") )
+      return err
     end
   end
 
@@ -135,6 +143,10 @@ module Ironfan
   #
   def self.step(name, desc, *style)
     ui.info("  #{"%-15s" % (name.to_s+":")}\t#{ui.color(desc.to_s, *style)}")
+  end
+
+  def self.substep(name, desc)
+    step(name, "  - #{desc}", :gray) if chef_config[:verbosity] >= 1
   end
 
   #
@@ -152,8 +164,8 @@ module Ironfan
     chef_config[:dry_run]
   end
 
-  # Intentionally skipping an implied step 
+  # Intentionally skipping an implied step
   def self.noop(source,method,*params)
-    Chef::Log.debug("Nothing to do for #{source}.#{method}(#{params.join(',')}), skipping")
+    # Chef::Log.debug("#{method} is a no-op for #{source} -- skipping (#{params.join(',')})")
   end
 end

--- a/lib/ironfan.rb
+++ b/lib/ironfan.rb
@@ -149,6 +149,11 @@ module Ironfan
     step(name, "  - #{desc}", :gray) if chef_config[:verbosity] >= 1
   end
 
+  # Output a TODO to the logs if you've switched on pestering
+  def self.todo(*args)
+    Chef::Log.debug(*args) if Chef::Config[:show_todo]
+  end
+
   #
   # Utility to do mock out a step during a dry-run
   #

--- a/lib/ironfan/broker.rb
+++ b/lib/ironfan/broker.rb
@@ -1,6 +1,6 @@
 # This module is intended to read in a cluster DSL description, and broker
 #   out to the various cloud providers, to control instance life-cycle and
-#   handle provider-specific amenities (SecurityGroup, Volume, etc.) for 
+#   handle provider-specific amenities (SecurityGroup, Volume, etc.) for
 #   them.
 module Ironfan
   def self.broker
@@ -10,15 +10,21 @@ module Ironfan
   class Broker < Builder
     # Take in a Dsl::Cluster, return Computers populated with
     #   all discovered resources that correlate, plus bogus computers
-    #   corresponding to 
+    #   corresponding to
     def discover!(cluster)
       # Get fully resolved servers, and build Computers using them
       computers = Computers.new(:cluster => cluster.resolve)
-      providers = computers.map{|c| c.providers.values}.flatten.uniq
-
-      providers.each {|p| p.load cluster }
+      #
+      providers = computers.map{|c| c.providers.values }.flatten.uniq
+      providers.each do |provider|
+        Ironfan.step cluster.name, "Loading #{provider.handle}", :cyan
+        provider.load cluster
+      end
+      #
+      Ironfan.step cluster.name, "Reconciling truth with beauty", :cyan
       computers.correlate
       computers.validate
+      #
       computers
     end
 

--- a/lib/ironfan/broker/computer.rb
+++ b/lib/ironfan/broker/computer.rb
@@ -61,7 +61,12 @@ module Ironfan
         target_resources = chosen_resources(options)
         resources.each do |res|
           next unless target_resources.include? res.class
-          res.destroy unless res.shared?
+          if res.shared?
+            Chef::Log.debug("Not killing shared resource #{res}")
+          else
+            Ironfan.step(self.name, "Killing #{res}")
+            res.destroy
+          end
         end
       end
 
@@ -206,7 +211,7 @@ module Ironfan
         not machine.nil?
       end
       def killable?
-        not permanent? and (node? or created?)
+        not permanent? and (node? || client? || created?)
       end
       def launchable?
         not bogus? and not created?

--- a/lib/ironfan/deprecated.rb
+++ b/lib/ironfan/deprecated.rb
@@ -2,7 +2,7 @@ module Ironfan
   def self.deprecated call, replacement=nil
     correction = ", " if replacement
     ui.error "The '#{call}' statement is deprecated#{correction} (in #{caller(2).first.inspect}). It looks like you are using an outdated DSL definition: please see https://github.com/infochimps-labs/ironfan/wiki/Upgrading-to-v4 for all the necessary upgrade steps."
-    exit(1)
+    raise StandardError, "Deprecated call to #{call} - #{replacement}", caller
   end
 
   class Dsl
@@ -11,7 +11,7 @@ module Ironfan
         Ironfan.deprecated 'defaults'
       end
     end
-    
+
     class Compute
       def cloud(provider=nil)
         if provider.nil?

--- a/lib/ironfan/dsl/server.rb
+++ b/lib/ironfan/dsl/server.rb
@@ -29,6 +29,9 @@ module Ironfan
         values
       end
 
+      # we should always show up in owners' inspect string
+      def inspect_compact ; inspect ; end
+
       # @returns [Hash{String, Array}] of 'what you did wrong' => [relevant, info]
       def lint
         errors = []

--- a/lib/ironfan/dsl/volume.rb
+++ b/lib/ironfan/dsl/volume.rb
@@ -30,7 +30,7 @@ module Ironfan
       })
 
       def snapshot_id(*)
-        Chef::Log.warn("CODE SMELL: EBS specific information in Dsl::Volume::VOLUME_IDS")
+        Ironfan.todo("CODE SMELL: EBS specific information in Dsl::Volume::VOLUME_IDS")
         super || VOLUME_IDS[snapshot_name]
       end
     end

--- a/lib/ironfan/provider.rb
+++ b/lib/ironfan/provider.rb
@@ -85,8 +85,9 @@ module Ironfan
 
       # Register and return the (adapted) object with the collection
       def self.register(native)
-        result = new(:adaptee => native)
-        remember result unless result.nil?
+        result = new(:adaptee => native) or return
+        remember result
+        result
       end
 
       def self.recall?(id)

--- a/lib/ironfan/provider.rb
+++ b/lib/ironfan/provider.rb
@@ -1,9 +1,10 @@
 # Providers present a lightweight wrapper for various third-party services,
 #   such as Chef's node and client APIs, and Amazon's EC2 APIs. This allows
-#   Ironfan ask specialized questions (such as whether a given resource 
+#   Ironfan ask specialized questions (such as whether a given resource
 #   matches
 module Ironfan
   class Provider < Builder
+    class_attribute :handle
 
     def self.receive(obj,&block)
       obj[:_type] = case obj[:name]
@@ -42,9 +43,11 @@ module Ironfan
 
       def bogus?()                      !bogus.empty?;          end
 
+      def self.handle ; name.to_s.gsub(/.*::/,'').to_sym ; end
+
       #
       # Flags
-      # 
+      #
       # Non-shared resources live and die with the computer
       def self.shared?()                true;                   end
       # Can multiple instances of this resource be associated with the computer?

--- a/lib/ironfan/provider/chef.rb
+++ b/lib/ironfan/provider/chef.rb
@@ -2,7 +2,8 @@ module Ironfan
   class Provider
 
     class ChefServer < Ironfan::Provider
-      
+      self.handle = :chef
+
       def self.resources
         [ Client, Node, Role ]
       end

--- a/lib/ironfan/provider/chef/client.rb
+++ b/lib/ironfan/provider/chef/client.rb
@@ -18,6 +18,11 @@ module Ironfan
           self.adaptee ||= Chef::ApiClient.new
         end
 
+        def to_s
+          "<%-15s %-23s %s>" % [
+            self.class.handle, name, key_filename]
+        end
+
         def self.shared?()              false;  end
         def self.multiple?()            false;  end
         def self.resource_type()        :client;                        end
@@ -42,9 +47,10 @@ module Ironfan
         def self.load!(cluster=nil)
           Ironfan.substep(cluster.name, "chef clients")
           nameq = "name:#{cluster.name}-* OR clientname:#{cluster.name}-*"
-          ChefServer.search(:client, nameq) do |client|
-            register client unless client.blank?
-            Chef::Log.debug("Loaded #{client.inspect}")
+          ChefServer.search(:client, nameq) do |raw|
+            next unless raw.present?
+            client = register(raw)
+            Chef::Log.debug("Loaded #{client}")
           end
         end
 

--- a/lib/ironfan/provider/chef/client.rb
+++ b/lib/ironfan/provider/chef/client.rb
@@ -3,11 +3,11 @@ module Ironfan
     class ChefServer
 
       class Client < Ironfan::Provider::Resource
-        delegate :add_to_index, :admin, :cdb_destroy, :cdb_save, 
-            :class_from_file, :couchdb, :couchdb=, :couchdb_id, :couchdb_id=, 
-            :couchdb_rev, :couchdb_rev=, :create, :create_keys, 
-            :delete_from_index, :destroy, :from_file, :index_id, :index_id=, 
-            :index_object_type, :name, :public_key, :save, :set_or_return, 
+        delegate :add_to_index, :admin, :cdb_destroy, :cdb_save,
+            :class_from_file, :couchdb, :couchdb=, :couchdb_id, :couchdb_id=,
+            :couchdb_rev, :couchdb_rev=, :create, :create_keys,
+            :delete_from_index, :destroy, :from_file, :index_id, :index_id=,
+            :index_object_type, :name, :public_key, :save, :set_or_return,
             :to_hash, :validate, :with_indexer_metadata,
           :to => :adaptee
         field :key_filename,    String,
@@ -40,13 +40,15 @@ module Ironfan
         # Discovery
         #
         def self.load!(cluster=nil)
+          Ironfan.substep(cluster.name, "chef clients")
           nameq = "name:#{cluster.name}-* OR clientname:#{cluster.name}-*"
           ChefServer.search(:client, nameq) do |client|
             register client unless client.blank?
+            Chef::Log.debug("Loaded #{client.inspect}")
           end
         end
 
-        # 
+        #
         # Manipulation
         #
         def self.create!(computer)

--- a/lib/ironfan/provider/chef/node.rb
+++ b/lib/ironfan/provider/chef/node.rb
@@ -30,6 +30,11 @@ module Ironfan
           self.adaptee ||= Chef::Node.new
         end
 
+        def to_s
+          "<%-15s %-23s %s>" % [
+            self.class.handle, name, run_list]
+        end
+
         def self.shared?()              false;  end
         def self.multiple?()            false;  end
 #         def self.resource_type()        self;   end
@@ -85,11 +90,9 @@ module Ironfan
         def self.load!(cluster=nil)
           Ironfan.substep(cluster.name, "nodes")
           ChefServer.search(:node,"name:#{cluster.name}-*") do |raw|
-            next if raw.blank?
-            node = Node.new
-            node.adaptee = raw
-            remember node
-            Chef::Log.debug("Loaded #{node.inspect}")
+            next unless raw.present?
+            node = register(raw)
+            Chef::Log.debug("Loaded #{node}")
           end
         end
 

--- a/lib/ironfan/provider/chef/node.rb
+++ b/lib/ironfan/provider/chef/node.rb
@@ -83,11 +83,13 @@ module Ironfan
         # Discovery
         #
         def self.load!(cluster=nil)
+          Ironfan.substep(cluster.name, "nodes")
           ChefServer.search(:node,"name:#{cluster.name}-*") do |raw|
             next if raw.blank?
             node = Node.new
             node.adaptee = raw
             remember node
+            Chef::Log.debug("Loaded #{node.inspect}")
           end
         end
 

--- a/lib/ironfan/provider/chef/role.rb
+++ b/lib/ironfan/provider/chef/role.rb
@@ -38,15 +38,20 @@ module Ironfan
           self
         end
 
+        def to_s
+          "<%-15s %-23s %s>" % [
+            self.class.handle, name, run_list]
+        end
+
         #
         # Discovery
         #
         def self.load!(cluster)
           Ironfan.substep(cluster.name, "roles")
           ChefServer.search(:role,"name:#{cluster.name}_*") do |raw|
-            next if raw.blank?
-            remember Role.new(:adaptee => raw)
-            Chef::Log.debug("Loaded #{raw.inspect}")
+            next unless raw.present?
+            role = register(raw)
+            Chef::Log.debug("Loaded #{role}")
           end
         end
 

--- a/lib/ironfan/provider/chef/role.rb
+++ b/lib/ironfan/provider/chef/role.rb
@@ -38,13 +38,15 @@ module Ironfan
           self
         end
 
-        # 
+        #
         # Discovery
         #
         def self.load!(cluster)
+          Ironfan.substep(cluster.name, "roles")
           ChefServer.search(:role,"name:#{cluster.name}_*") do |raw|
             next if raw.blank?
             remember Role.new(:adaptee => raw)
+            Chef::Log.debug("Loaded #{raw.inspect}")
           end
         end
 

--- a/lib/ironfan/provider/ec2.rb
+++ b/lib/ironfan/provider/ec2.rb
@@ -2,6 +2,7 @@ module Ironfan
   class Provider
 
     class Ec2 < Ironfan::IaasProvider
+      self.handle = :ec2
 
       def self.resources
         [ Machine, EbsVolume, KeyPair, SecurityGroup ]
@@ -18,7 +19,7 @@ module Ironfan
           :region                => Chef::Config[:knife][:region]
         })
       end
-      
+
       def self.aws_account_id()
         Chef::Config[:knife][:aws_account_id]
       end

--- a/lib/ironfan/provider/ec2/ebs_volume.rb
+++ b/lib/ironfan/provider/ec2/ebs_volume.rb
@@ -16,6 +16,11 @@ module Ironfan
           :to => :adaptee
         field :dsl_volume,        Ironfan::Dsl::Volume
 
+        def to_s
+          "<%-15s %-12s %-25s %-32s %-10s %-12s %-15s %-5s %s:%s>" % [
+            self.class.handle, id, created_at, tags['name'], state, device, tags['mount_point'], size, server_id, attached_at ]
+        end
+
         def self.shared?()      true;   end
         def self.multiple?()    true;   end
         def self.resource_type()        :ebs_volume;   end
@@ -44,6 +49,7 @@ module Ironfan
         # Discovery
         #
         def self.load!(cluster=nil)
+          Ironfan.substep(cluster.name, "volumes")
           Ec2.connection.volumes.each do |vol|
             next if vol.blank?
             ebs = EbsVolume.new(:adaptee => vol)
@@ -55,6 +61,7 @@ module Ironfan
             else
               remember ebs
             end
+            Chef::Log.debug("Loaded #{ebs}")
           end
         end
 

--- a/lib/ironfan/provider/ec2/key_pair.rb
+++ b/lib/ironfan/provider/ec2/key_pair.rb
@@ -25,12 +25,18 @@ module Ironfan
           File.open(key_filename, "w", 0600){|f| f.print( body ) }
         end
 
+        def to_s
+          "<%-15s %-12s>" % [self.class.handle, name]
+        end
+
         #
         # Discovery
         #
         def self.load!(cluster=nil)
+          Ironfan.substep(cluster.name, "keypairs")
           Ec2.connection.key_pairs.each do |keypair|
             register keypair unless keypair.blank?
+            Chef::Log.debug("Loaded <%-15s %s>" % [handle, keypair.name])
           end
         end
 

--- a/lib/ironfan/provider/ec2/key_pair.rb
+++ b/lib/ironfan/provider/ec2/key_pair.rb
@@ -33,7 +33,7 @@ module Ironfan
         # Discovery
         #
         def self.load!(cluster=nil)
-          Ironfan.substep(cluster.name, "keypairs")
+          Ironfan.substep(cluster && cluster.name, "keypairs")
           Ec2.connection.key_pairs.each do |keypair|
             register keypair unless keypair.blank?
             Chef::Log.debug("Loaded <%-15s %s>" % [handle, keypair.name])

--- a/lib/ironfan/provider/ec2/placement_group.rb
+++ b/lib/ironfan/provider/ec2/placement_group.rb
@@ -11,10 +11,16 @@ module Ironfan
           self["groupName"]
         end
 
+        def to_s
+          "<%-15s %-12s %-12s>" % [ self.class.handle, '', name ]
+        end
+
         def self.load!(cluster)
+          Ironfan.substep(cluster.name, "placement groups")
           result = Ec2.connection.describe_placement_groups
           result.body["placementGroupSet"].each do |group|
             register group unless group.blank?
+            Chef::Log.debug("Loaded #{group.inspect}")
           end
         end
       end

--- a/lib/ironfan/provider/virtualbox.rb
+++ b/lib/ironfan/provider/virtualbox.rb
@@ -2,6 +2,7 @@ module Ironfan
   class Provider
 
     class VirtualBox < Ironfan::IaasProvider
+      self.handle = :virtualbox
     end
 
   end


### PR DESCRIPTION
If the client existed but the node did not, knife cluster kill would ignore the server. In Cosa Nostra when a client gives you agita you give it lead.

A server is now `killable?` if it has a node, a client, or a created machine. Also added progress report to the killination.
