### PR TITLE
Ubuntu 12.04 bootstrap support (fixes #135)

### DIFF
--- a/lib/chef/knife/bootstrap/ubuntu12.04-ironfan.erb
+++ b/lib/chef/knife/bootstrap/ubuntu12.04-ironfan.erb
@@ -1,0 +1,131 @@
+bash <<'EOF' || echo "Chef bootstrap failed!"
+
+# This is the ubuntu precise bootstrap script from infochimps' ironfan. It is
+# based on the opscode bootstrap script, with the important differences being it:
+#
+# * installs the Opscode-provided Chef client (including a self-contained Ruby 1.9.x) in /opt/chef
+# * installs certain universally-useful gems into the Chef-provided Ruby gem set
+# * pushes the node identity into the first-boot.json
+# * installs the chef-client service and kicks off the first run of chef
+
+<%= "export http_proxy=\"#{knife_config[:bootstrap_proxy]}\"" if knife_config[:bootstrap_proxy] -%>
+
+set -e
+
+<%= (@config[:verbosity].to_i > 1 ? 'set -v' : '') %>
+
+date > /etc/box_build_time
+
+echo -e "`date` \n\n**** \n**** apt update:\n****\n"
+apt-get --force-yes -y update
+apt-get --force-yes -y upgrade
+
+echo -e "`date` \n\n**** \n**** Installing base packages:\n****\n"
+apt-get --force-yes -y install build-essential make wget curl runit zlib1g-dev libssl-dev openssl libcurl4-openssl-dev libxml2-dev libxslt-dev libyaml-dev libreadline6 libreadline6-dev
+apt-get clean
+
+# do not trust the ubuntu chef package
+rm -f /etc/init.d/chef-client || true
+apt-get   remove -y --force-yes         chef ruby1.8-dev libjson-ruby1.8 libmixlib-authentication-ruby1.8 ohai libmixlib-log-ruby1.8 libmime-types-ruby librestclient-ruby1.8 ruby1.8 ruby liberubis-ruby1.8 libsystemu-ruby1.8 libohai-ruby libuuidtools-ruby1.8 libhighline-ruby1.8 libabstract-ruby1.8 libmixlib-config-ruby1.8 rubygems1.8 libbunny-ruby1.8 libchef-ruby1.8 libmixlib-cli-ruby1.8 libyajl-ruby libmoneta-ruby1.8 libohai-ruby1.8 libextlib-ruby1.8 || true
+sudo apt-get autoremove -y --force-yes || true
+
+mkdir -p /tmp/knife-bootstrap
+chmod 700 /tmp/knife-bootstrap 
+cd /tmp/knife-bootstrap
+
+eval `cat /etc/lsb-release `
+export DEBIAN_FRONTEND=noninteractive
+
+# Install a self-contained Chef client because Ubuntu ships with Ruby 1.8.x,
+# which is not compatible with Ironfan
+echo 'gem: --no-ri --no-rdoc' > /home/ubuntu/.gemrc
+echo 'gem: --no-ri --no-rdoc' > /root/.gemrc
+if [ ! -f /opt/chef/bin/chef-client ]; then
+  curl -L http://www.opscode.com/chef/install.sh | sudo bash
+fi
+/opt/chef/embedded/bin/gem install extlib bundler json right_aws pry fog
+
+echo -e "`date` \n\n**** \n**** Knifing in the chef client config files:\n****\n"
+mkdir -p /etc/chef
+
+<%- if @config[:client_key] %>
+(
+cat <<'EOP'
+<%= @config[:client_key] %>
+EOP
+) > /tmp/knife-bootstrap/client.pem
+awk NF /tmp/knife-bootstrap/client.pem > /etc/chef/client.pem
+<%- else %>
+(
+cat <<'EOP'
+<%= validation_key %>
+EOP
+) > /tmp/knife-bootstrap/validation.pem
+awk NF /tmp/knife-bootstrap/validation.pem > /etc/chef/validation.pem
+<%- end %>
+
+<% if @chef_config[:encrypted_data_bag_secret] -%>
+(
+cat <<'EOP'
+<%= encrypted_data_bag_secret %>
+EOP
+) > /tmp/encrypted_data_bag_secret
+awk NF /tmp/encrypted_data_bag_secret > /etc/chef/encrypted_data_bag_secret
+rm /tmp/encrypted_data_bag_secret
+<% end -%>
+
+(
+cat <<'EOP'
+<%= config_content %>
+<%= @config[:computer].chef_client_script_content %>
+EOP
+) > /etc/chef/client.rb
+
+(
+cat <<'EOP'
+<%= { "run_list" => @run_list, "cluster_name" => @config[:server].cluster_name, "facet_name" => @config[:server].facet_name, "facet_index" => @config[:server].index }.to_json %>
+EOP
+) > /etc/chef/first-boot.json
+
+echo -e "`date` \n\n**** \n**** Adding chef client runit scripts:\n****\n"
+( service chef-client stop >/dev/null 2>&1 ; sleep 1 ; killall chef-client 2>/dev/null ) || true
+mkdir -p /var/log/chef /var/chef /etc/service /etc/sv/chef-client/{log/main,supervise} 
+cat > /etc/sv/chef-client/log/run <<'EOP'
+#!/bin/bash
+exec svlogd -tt ./main
+EOP
+cat > /etc/sv/chef-client/run <<'EOP'
+#!/bin/bash
+exec 2>&1
+exec /usr/bin/env chef-client -i 43200 -s 20 -L /var/log/chef/client.log
+EOP
+chmod +x  /etc/sv/chef-client/log/run /etc/sv/chef-client/run
+ln -nfs /usr/bin/sv /etc/init.d/chef-client
+
+service chef-client stop >/dev/null 2>&1 || true
+
+<%- if (@config[:bootstrap_runs_chef_client].to_s == 'true') || (@chef_config.knife[:bootstrap_runs_chef_client].to_s == 'true') %>
+(
+cat <<'EOP'
+echo -e "`date` \n\n**** \n**** First run of chef:\n****\n"
+set -e
+<%= start_chef %>
+set +e
+<%- end %>
+EOP
+) > /tmp/chef_first_run.sh
+chmod +x /tmp/chef_first_run.sh
+/tmp/chef_first_run.sh
+
+echo -e "`date` \n\n**** \n**** Cleanup:\n****\n"
+cd /
+rm -r /tmp/knife-bootstrap
+# make locate work good
+updatedb
+
+echo -e "`date` \n\n**** \n**** Enabling chef client service:\n****\n"
+ln -nfs /etc/sv/chef-client /etc/service/chef-client
+service chef-client start || true
+
+echo -e "`date` \n\n**** \n**** Cluster Chef client bootstrap complete\n****\n"
+EOF


### PR DESCRIPTION
This bootstrap template uses the Opscode-provided Chef installer in /opt/chef including a self-contained Ruby installation. This is done to work around the fact that the Chef client that ships with Ubuntu 12.04 has dependencies on the Ubuntu-provided Ruby 1.8.7 packages.
