### PR TITLE
Suppress error when security groups are reloaded after initial creation

### DIFF
--- a/lib/ironfan/provider/ec2/security_group.rb
+++ b/lib/ironfan/provider/ec2/security_group.rb
@@ -24,7 +24,7 @@ module Ironfan
         # Discovery
         #
         def self.load!(cluster=nil)
-          Ironfan.substep(cluster.name, "security groups")
+          Ironfan.substep(cluster && cluster.name, "security groups")
 
           Ec2.connection.security_groups.each do |raw|
             next if raw.blank?


### PR DESCRIPTION
Based on and identical in reasoning to 6ff6be49
