### PR TITLE
Terminated machines are not bogus (fixes #165)

### DIFF
--- a/lib/chef/knife/cluster_show.rb
+++ b/lib/chef/knife/cluster_show.rb
@@ -35,6 +35,7 @@ class Chef
         :boolean     => true
 
       def run
+        with_verbosity(1){ config[:include_terminated] }
         load_ironfan
         die(banner) if @name_args.empty?
         configure_dry_run

--- a/lib/ironfan/provider/ec2/ebs_volume.rb
+++ b/lib/ironfan/provider/ec2/ebs_volume.rb
@@ -52,6 +52,7 @@ module Ironfan
           Ironfan.substep(cluster.name, "volumes")
           Ec2.connection.volumes.each do |vol|
             next if vol.blank?
+            next if %w[deleting deleted error].include?(vol.state.to_s)
             ebs = EbsVolume.new(:adaptee => vol)
             # Already have a volume by this name
             if recall? ebs.name

--- a/lib/ironfan/provider/ec2/machine.rb
+++ b/lib/ironfan/provider/ec2/machine.rb
@@ -105,15 +105,16 @@ module Ironfan
           Ironfan.substep(cluster.name, "machines")
           Ec2.connection.servers.each do |fs|
             machine = new(:adaptee => fs)
-            if recall? machine.name
+            if (not machine.created?)
+              next unless Ironfan.chef_config[:include_terminated]
+              remember machine, :append_id => "terminated:#{machine.id}"
+            elsif recall? machine.name
               raise 'duplicate'
               machine.bogus <<                 :duplicate_machines
               recall(machine.name).bogus <<    :duplicate_machines
               remember machine, :append_id => "duplicate:#{machine.id}"
-            elsif machine.created?
+            else # never seen it
               remember machine
-            else
-              remember machine, :append_id => "terminated:#{machine.id}"
             end
             Chef::Log.debug("Loaded #{machine}")
           end
@@ -168,7 +169,7 @@ module Ironfan
             'name' =>         computer.name,
             'Name' =>         computer.name,
           }
-          Ec2.ensure_tags(tags,computer.machine)
+          Ec2.ensure_tags(tags, computer.machine)
 
           # register the new volumes for later save!, and tag appropriately
           computer.machine.volumes.each do |v|


### PR DESCRIPTION
The dead are not bogus (Bill & Ted I), they're ghosts (Bill & Ted II). This fixes #165.
- terminated machines are skipped, as they were in old ironfan.
- ...except in the case of knife cluster show, which accepts them as there-but-bogus if verbosity > 1.
