### PR TITLE
Use Chef::Node-friendly semantics for chef_environment

### DIFF
--- a/lib/ironfan/provider/chef/node.rb
+++ b/lib/ironfan/provider/chef/node.rb
@@ -6,7 +6,7 @@ module Ironfan
         delegate :[], :[]=, :add_to_index, :apply_expansion_attributes,
             :attribute, :attribute=, :attribute?, :automatic_attrs,
             :automatic_attrs=, :cdb_destroy, :cdb_save, :chef_environment,
-            :chef_environment=, :chef_server_rest, :class_from_file,
+            :chef_server_rest, :class_from_file,
             :construct_attributes, :consume_attributes,
             :consume_external_attrs, :consume_run_list, :cookbook_collection,
             :cookbook_collection=, :couchdb, :couchdb=, :couchdb_id,
@@ -64,9 +64,8 @@ module Ironfan
         def prepare_from(computer)
           organization =                Chef::Config.organization
           normal[:organization] =       organization unless organization.nil?
-
           server =                      computer.server
-          chef_environment =            server.environment
+          chef_environment(server.environment.to_s)
           run_list.instance_eval        { @run_list_items = server.run_list }
           normal[:cluster_name] =       server.cluster_name
           normal[:facet_name] =         server.facet_name


### PR DESCRIPTION
Chef::Node uses a single function #set_or_return to manage the chef_environment
instance variable, but Ironfan::Provider::ChefServer::Node uses delegation
through #chef_environment and #chef_environment=. Unfortunately, magic in the
Chef mixins causes #chef_environment to go through the "correct" get/setter
while the call to #chef_environment= gets stashed uselessly in self's Hash
representation (rather than an instance variable of self). The net result is
that the attempt to copy server.environment into a new Node's chef_environment
attribute was getting silently dropped on the floor, and all new nodes were
being created in the _default environment :-(

This patch fixes that disconnect, and also allows nice folks to use symbols
for their Chef environment names if that sort of thing makes them happy.
