### PR TITLE
facet specs (doesn't help #183, but does narrow it down)

### DIFF
--- a/lib/ironfan.rb
+++ b/lib/ironfan.rb
@@ -63,7 +63,8 @@ module Ironfan
     name = name.to_sym
     # If this is being called as Ironfan.cluster('foo') with no additional arguments,
     # return the cached cluster object if it exists
-    if @@clusters[name] and attrs.empty? and not block_given?
+    if @@clusters[name]
+      @@clusters[name].receive!(attrs, &block)
       return @@clusters[name]
     else # Otherwise we're being asked to (re)initialize and cache a cluster definition
       cl = Ironfan::Dsl::Cluster.new(:name => name)

--- a/lib/ironfan/dsl/cluster.rb
+++ b/lib/ironfan/dsl/cluster.rb
@@ -4,7 +4,7 @@ module Ironfan
     class Cluster < Ironfan::Dsl::Compute
       collection :facets,       Ironfan::Dsl::Facet,   :resolver => :deep_resolve
 
-      def initialize(attrs={},&block)
+      def initialize(attrs={}, &block)
         super
         self.cluster_role       Ironfan::Dsl::Role.new(:name => "#{attrs[:name]}_cluster")
       end

--- a/spec/ironfan/cluster_spec.rb
+++ b/spec/ironfan/cluster_spec.rb
@@ -4,7 +4,7 @@ require 'ironfan'
 
 describe Ironfan::Dsl::Cluster do
   subject do
-    Ironfan.cluster 'foo' do
+    Ironfan.cluster 'troop' do
       environment :dev
 
       role :generic
@@ -14,6 +14,7 @@ describe Ironfan::Dsl::Cluster do
     end
   end
 
+  its(:name)        { should eql 'troop' }
   its(:environment) { should eql :dev }
 
   its(:run_list) { should eql [
@@ -22,4 +23,14 @@ describe Ironfan::Dsl::Cluster do
     "role[is_last]"
     ]
   }
+
+  context '.facet' do
+    it 'should give the same facet back for the same name' do
+      facet_1 = subject.facet(:bob){ instances(1) }
+      facet_2 = subject.facet(:bob){ instances(2) }
+      facet_1.should == facet_2
+      facet_1.should == subject.facet(:bob)
+      facet_1.instances.should == 2
+    end
+  end
 end

--- a/spec/ironfan/facet_spec.rb
+++ b/spec/ironfan/facet_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+require 'ironfan'
+
+describe Ironfan::Dsl::Facet do
+  let :troop do
+    Ironfan.cluster :troop do
+      environment :dev
+
+      role      :generic
+      role      :is_last, :last
+      role      :is_first, :first
+
+      facet :happy do
+        role    :generic
+      end
+    end
+  end
+
+  context 'dsl' do
+    subject{ troop.facet(:happy) }
+
+    its(:name)        { should eql 'happy' }
+    its(:environment) { should eql :dev }
+
+    its(:run_list) { should eql [
+        "role[is_first]",
+        "role[generic]",
+        "role[is_last]"
+      ]
+    }
+
+    it 'sets instances' do
+      subject.instances.should == 1
+      subject.instances(2)
+      subject.instances.should == 2
+    end
+
+    it 'wtf' do
+      troop.receive! do
+        facet(:sneezy).cloud(:ec2).bits(32)
+        facet(:sneezy).instances.should == 1
+        facet :sneezy do
+          self.instances.should == 1
+          instances(2)
+          self.instances.should == 2
+        end
+        facet(:sneezy).instances.should == 2
+      end
+      troop.facet(:sneezy).instances.should == 2
+    end
+
+    context 'run list ordering' do
+      it "facet :first roles follow cluster :first roles" do
+        subject.role(:even_firster, :first)
+        subject.run_list.should == [ "role[is_first]", "role[even_firster]", "role[generic]", "role[is_last]" ]
+      end
+      it "facet :last roles follow cluster :last roles" do
+        subject.role(:even_laster, :last)
+        subject.run_list.should == [ "role[is_first]", "role[generic]", "role[is_last]", "role[even_laster]" ]
+      end
+    end
+  end
+
+end

--- a/spec/ironfan_spec.rb
+++ b/spec/ironfan_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+require 'ironfan'
+
+describe Ironfan do
+  context '.cluster' do
+    it 'should auto-vivify the cluster definition' do
+      Ironfan.cluster('troop')
+      Ironfan.clusters.values.map(&:name).should == ['troop']
+    end
+    #
+    it 'should give the same cluster back for the same name' do
+      cl1 = Ironfan.cluster('troop'){ facet(:a) }
+      cl2 = Ironfan.cluster('troop'){ facet(:b) }
+      cl1.should equal(cl2)
+    end
+    #
+    it 'should eval a given block in context of the cluster' do
+      Ironfan.cluster('troop'){ environment :set_in_block }
+      Ironfan.cluster('troop').environment.should == :set_in_block
+    end
+    it 'adopts attribute hash if given' do
+      Ironfan.cluster('troop', environment: :set_in_hash)
+      Ironfan.cluster('troop').environment.should == :set_in_hash
+    end
+  end
+end


### PR DESCRIPTION
The instances do get overridden correctly in the dsl.

Found another problem, which is that repeated calls to `Ironfan.cluster()` should NOT replace the cluster definition.
