### PR TITLE
stringification of attributes and in_raid type

### DIFF
--- a/lib/ironfan/broker/drive.rb
+++ b/lib/ironfan/broker/drive.rb
@@ -12,7 +12,6 @@ module Ironfan
       def node()
         result = super.stringify_keys
         result.merge! volume.compact_attributes.stringify_keys unless volume.nil?
-        puts [self, volume, volume && volume.compact_attributes].inspect
         result
       end
 

--- a/lib/ironfan/broker/drive.rb
+++ b/lib/ironfan/broker/drive.rb
@@ -10,8 +10,9 @@ module Ironfan
 
       # A drive should include volume attributes in any node references
       def node()
-        result = super
-        result.merge! volume.attributes unless volume.nil?
+        result = super.stringify_keys
+        result.merge! volume.compact_attributes.stringify_keys unless volume.nil?
+        puts [self, volume, volume && volume.compact_attributes].inspect
         result
       end
 

--- a/lib/ironfan/dsl/volume.rb
+++ b/lib/ironfan/dsl/volume.rb
@@ -10,7 +10,7 @@ module Ironfan
       magic     :device,                String
       magic     :formattable,           :boolean, :default => false
       magic     :fstype,                String,   :default => 'xfs'
-      magic     :in_raid,               :boolean, :default => false
+      magic     :in_raid,               String
       magic     :keep,                  :boolean, :default => true
       magic     :mount_dump,            String
       magic     :mount_pass,            String

--- a/lib/ironfan/dsl/volume.rb
+++ b/lib/ironfan/dsl/volume.rb
@@ -11,9 +11,6 @@ module Ironfan
       magic     :formattable,           :boolean, :default => false
       magic     :fstype,                String,   :default => 'xfs'
       magic     :in_raid,               String
-
-      puts "jbro-ironfan"
-
       magic     :keep,                  :boolean, :default => true
       magic     :mount_dump,            String
       magic     :mount_pass,            String

--- a/lib/ironfan/dsl/volume.rb
+++ b/lib/ironfan/dsl/volume.rb
@@ -11,6 +11,9 @@ module Ironfan
       magic     :formattable,           :boolean, :default => false
       magic     :fstype,                String,   :default => 'xfs'
       magic     :in_raid,               String
+
+      puts "jbro-ironfan"
+
       magic     :keep,                  :boolean, :default => true
       magic     :mount_dump,            String
       magic     :mount_pass,            String


### PR DESCRIPTION
I'm seeing trouble with symbolic names for keys. The DSL was setting :in_raid somewhere when the right key was "in_raid." Also, compact_attributes should be used rather than attributes so that nil attributes don't clobber things, says Flip. In addition, the type of the in_raid field is String, not boolean.

Flip requests that you look for other similar places that use attributes rather than compact_attributes.
