### PR TITLE
workaround to make ec2 regions respect the cluster's region/AZ preference

### DIFF
--- a/lib/chef/knife/ironfan_knife_common.rb
+++ b/lib/chef/knife/ironfan_knife_common.rb
@@ -36,6 +36,7 @@ module Ironfan
       #
       ui.info("Inventorying servers in #{desc}")
       cluster   = Ironfan.load_cluster(cluster_name)
+      Chef::Config[:knife][:region] = cluster.servers.to_a.first.cloud(:ec2).region
       computers =  broker.discover! cluster
       Chef::Log.info("Inventoried #{computers.size} computers")
       #

--- a/lib/ironfan/dsl/ec2.rb
+++ b/lib/ironfan/dsl/ec2.rb
@@ -38,7 +38,7 @@ module Ironfan
         bit_str = "#{self.bits.to_i}-bit" # correct for legacy image info.
         keys = [region, bit_str, backing, image_name]
         info = Chef::Config[:ec2_image_info][ keys ]
-        ui.warn("Can't find image for #{[region, bits.to_s, backing, image_name].inspect}") if info.blank?
+        ui.warn("Can't find image for #{[region, bit_str, backing, image_name].inspect}") if info.blank?
         return info || {}
       end
 

--- a/lib/ironfan/provider/ec2/machine.rb
+++ b/lib/ironfan/provider/ec2/machine.rb
@@ -204,6 +204,10 @@ module Ironfan
           errors["No AMI found"] = info if cloud.image_id.blank?
           errors['Missing client']      = info            unless computer.client?
           errors['Missing private_key'] = computer.client unless computer.private_key
+          #
+          all_asserted_regions = [Ec2.connection.region, cloud.region, Chef::Config[:knife][:region], Ironfan.chef_config[:region]].compact.uniq
+          errors["mismatched region"] = all_asserted_regions unless all_asserted_regions.count == 1
+          #
           errors
         end
 


### PR DESCRIPTION
I don't know the right way to do this:
- what do you do if multiple AZs are requested? I think it's like the chef environment thing -- you check, and fail the command.
- This probably shouldn't come from 'Chef::Config[:knife][:region]'. it's a delicate dance: you need to have loaded the cluster, but _not_ triggered the Ec2.connection virtual accessor.  I think the Ec2.connection should not auto-vivify itself -- the knife command should have to explicitly invoke Ec2.connect or something.
