### PR TITLE
Fixes nested array bug when computing list of AZs for an ELB

### DIFF
--- a/lib/ironfan/provider/ec2/elastic_load_balancer.rb
+++ b/lib/ironfan/provider/ec2/elastic_load_balancer.rb
@@ -101,8 +101,8 @@ module Ironfan
           # Did the list of availability zones for this ELB change?
           if availability_zones != elb.availability_zones.sort
             Ironfan.step(elb.name, "  updating availability zones to #{availability_zones.join(', ')}", :blue)
-            to_add    = [ availability_zones - elb.availability_zones ]
-            to_remove = [ elb.availability_zones - availability_zones ]
+            to_add    = availability_zones - elb.availability_zones
+            to_remove = elb.availability_zones - availability_zones
             elb.enable_availability_zones(to_add) unless to_add.empty?
             elb.disable_availability_zones(to_remove) unless to_remove.empty?
           end


### PR DESCRIPTION
This patch ensures that the list of availability zones to be added or removed from an ELB (computed by uniquifying the list of all AZs in which there are EC2 instances of interest) is an array, rather than an array of arrays.

It's a miracle the code ever worked as it was written.
