### PR TITLE
Bugfix/overzealous elastic ips

### DIFF
--- a/lib/ironfan/provider/ec2/elastic_ip.rb
+++ b/lib/ironfan/provider/ec2/elastic_ip.rb
@@ -51,11 +51,12 @@ module Ironfan
 
         def self.save!(computer)
           return unless computer.created?
-          elastic_ip = computer.server.ec2.elastic_ip
-          Ironfan.step(computer.name, "associating Elastic IP #{elastic_ip}", :blue)
-          Ironfan.unless_dry_run do
-            Ironfan.safely do
-              Ec2.connection.associate_address( computer.machine.id, elastic_ip )
+          if elastic_ip = computer.server.ec2.elastic_ip
+            Ironfan.step(computer.name, "associating Elastic IP #{elastic_ip}", :blue)
+              Ironfan.unless_dry_run do
+                Ironfan.safely do
+                Ec2.connection.associate_address( computer.machine.id, elastic_ip )
+              end
             end
           end
         end


### PR DESCRIPTION
Without this patch, facets which do _not_ specify an elastic_ip will get an error like this:

```
Syncing to Chef:
Syncing to cloud:
  prod-services-1:  setting termination flag false
  prod-services-1:  associating Elastic IP 
WARNING: Error running :
WARNING: MissingParameter => Either public IP or allocation id must be specified
ERROR: MissingParameter => Either public IP or allocation id must be specified (Fog::Compute::AWS::Error)
/Users/nick/.rvm/gems/ruby-1.9.3-p194@ironfan-homebase/gems/excon-0.16.4/lib/excon/connection.rb:290:in `request_kernel'
```
