### PR TITLE
Allow per-ephemeral-disk options using :disks attribute

### DIFF
--- a/lib/ironfan/dsl/ec2.rb
+++ b/lib/ironfan/dsl/ec2.rb
@@ -104,7 +104,13 @@ module Ironfan
             mount_options       'defaults,noatime'
             tags({:bulk => true, :local => true, :fallback => true})
           end
-          ephemeral.receive! mount_ephemerals
+          ephemeral_attrs = mount_ephemerals.clone
+          if ephemeral_attrs.has_key?(:disks)
+            disk_attrs = mount_ephemerals[:disks][idx] || { }
+            ephemeral_attrs.delete(:disks)
+            ephemeral_attrs.merge!(disk_attrs)
+          end
+          ephemeral.receive! ephemeral_attrs
           result << ephemeral
         end
         result

--- a/spec/ironfan/ec2/cloud_provider_spec.rb
+++ b/spec/ironfan/ec2/cloud_provider_spec.rb
@@ -13,6 +13,10 @@ describe Ironfan::Dsl::Cluster do
 
       facet :web do
         instances 3
+        cloud(:ec2) do
+          flavor 'm1.small'
+          mount_ephemerals({ :disks => { 0 => { :mount_point => '/data' } } })
+        end
       end
 
     end
@@ -29,6 +33,10 @@ describe Ironfan::Dsl::Cluster do
 
     it 'should have one cloud provider, EC2' do
       @facet.servers[0].clouds.keys.should == [ :ec2 ]
+    end
+
+    it 'should have its first ephemeral disk mounted at /data' do
+      @facet.servers[0].implied_volumes[1].mount_point.should == '/data'
     end
   end
 


### PR DESCRIPTION
This is the (simple) concrete version of what I mentioned on the ironfan-users mailing list.

In effect, this allows you to provide volume attributes, on a per-ephemeral-disk basis. My own motivation was to be able to override the :mount_point attribute.
