### PR TITLE
Bogus servers should not be killable (fixes #250)

### DIFF
--- a/lib/chef/knife/cluster_bootstrap.rb
+++ b/lib/chef/knife/cluster_bootstrap.rb
@@ -62,7 +62,6 @@ class Chef
         ensure_common_environment(target)
         # Execute across all servers in parallel
         Ironfan.parallel(target.values) {|computer| run_bootstrap(computer)}
-#         threads = target.servers.map{ |server| Thread.new(server) { |svr| run_bootstrap(svr, svr.public_hostname) } }
       end
 
       def confirm_execution(target)

--- a/lib/chef/knife/cluster_start.rb
+++ b/lib/chef/knife/cluster_start.rb
@@ -24,7 +24,7 @@ class Chef
       import_banner_and_options(Ironfan::Script)
 
       def relevant?(server)
-        server.stopped?
+        (not bogus?) && stopped?
       end
 
       def perform_execution(target)

--- a/lib/chef/knife/cluster_stop.rb
+++ b/lib/chef/knife/cluster_stop.rb
@@ -24,7 +24,7 @@ class Chef
       import_banner_and_options(Ironfan::Script)
 
       def relevant?(server)
-        server.running?
+        (not bogus?) && server.running?
       end
 
       def perform_execution(target)

--- a/lib/chef/knife/ironfan_knife_common.rb
+++ b/lib/chef/knife/ironfan_knife_common.rb
@@ -84,19 +84,18 @@ module Ironfan
     #
     def get_relevant_slice( *predicate )
       full_target = get_slice( *predicate )
-      display(full_target) do |m|
-        rel = relevant?(m)
-        { :relevant? => (rel ? "[blue]#{rel}[reset]" : '-' ) }
+      display(full_target) do |mach|
+        rel = relevant?(mach)
+        { :relevant? => (rel ? "[green]#{rel}[reset]" : '-' ) }
       end
-      full_target.select{|m| relevant?(m) }
+      full_target.select{|mach| relevant?(mach) }
     end
 
     # passes target to Broker::Conductor#display, will show headings in server slice
     # tables based on the --verbose flag
     def display(target, display_style=nil, &block)
       display_style ||= (config[:verbosity] == 0 ? :default : :expanded)
-#       target.display(ui, display_style, &block)
-      broker.display(target, display_style)
+      broker.display(target, display_style, &block)
     end
 
     #

--- a/lib/ironfan/broker.rb
+++ b/lib/ironfan/broker.rb
@@ -31,11 +31,15 @@ module Ironfan
     end
 
     def display(computers,style)
-      defined_data = computers.map {|m| m.to_display(style) }
+      defined_data = computers.map do |mach|
+        hsh = mach.to_display(style)
+        hsh.merge!(yield(mach)) if block_given?
+        hsh
+      end
       if defined_data.empty?
         ui.info "Nothing to report"
       else
-        headings = defined_data.map{|r| r.keys}.flatten.uniq
+        headings = defined_data.map{|hsh| hsh.keys }.flatten.uniq
         Formatador.display_compact_table(defined_data, headings.to_a)
       end
     end

--- a/lib/ironfan/provider/ec2/security_group.rb
+++ b/lib/ironfan/provider/ec2/security_group.rb
@@ -19,6 +19,7 @@ module Ironfan
         def self.multiple?()    true;   end
         def self.resource_type()        :security_group;   end
         def self.expected_ids(computer)
+          return unless computer.server
           ec2 = computer.server.cloud(:ec2)
           ec2.security_groups.keys.map { |name| group_name_with_vpc(name,ec2.vpc) }.uniq
         end
@@ -73,7 +74,7 @@ module Ironfan
           # First, deduce the list of all groups to which at least one instance belongs
           # We'll use this later to decide whether to create groups, or authorize access,
           # using a VPC security group or an EC2 security group.
-          groups_that_should_exist = computers.map { |c| expected_ids(c) }.flatten.sort.uniq
+          groups_that_should_exist = computers.map{|comp| expected_ids(comp) }.flatten.compact.sort.uniq
           groups_to_create << groups_that_should_exist
 
           computers.select { |computer| Ec2.applicable computer }.each do |computer|


### PR DESCRIPTION
- style guide corrections ('&&', not 'and'; don't use single-letter variable names)
- also fixed a thing where security groups enumeration would die if a bogus server existed that's bit me before
- reviewed other knife cluster commands and made them not tolerate bogosity either
