### PR TITLE
Added the m3 flavors to ec2_flavor_info

### DIFF
--- a/lib/ironfan/dsl/ec2.rb
+++ b/lib/ironfan/dsl/ec2.rb
@@ -293,8 +293,10 @@ Chef::Config[:ec2_flavor_info].merge!({
     #
     'm1.large'    => { :price => 0.32,  :bits => 64, :ram =>   7680, :cores => 2, :core_size => 2,    :inst_disks => 2, :inst_disk_size =>  850, :ephemeral_volumes => 2, :ebs_optimizable =>  500, },
     'm2.xlarge'   => { :price => 0.45,  :bits => 64, :ram =>  18124, :cores => 2, :core_size => 3.25, :inst_disks => 1, :inst_disk_size =>  420, :ephemeral_volumes => 1 },
+    'm3.xlarge'   => { :price => 0.50,  :bits => 64, :ram =>  15360, :cores => 4, :core_size => 3.25, :inst_disks => 0, :inst_disk_size =>  0,   :ephemeral_volumes => 0 },
     'c1.xlarge'   => { :price => 0.64,  :bits => 64, :ram =>   7168, :cores => 8, :core_size => 2.5,  :inst_disks => 4, :inst_disk_size => 1690, :ephemeral_volumes => 4 },
     'm1.xlarge'   => { :price => 0.66,  :bits => 64, :ram =>  15360, :cores => 4, :core_size => 2,    :inst_disks => 4, :inst_disk_size => 1690, :ephemeral_volumes => 4, :ebs_optimizable => 1000, },
+    'm3.2xlarge'  => { :price => 1.00, :bits => 64, :ram =>  30720, :cores => 8, :core_size => 3.25, :inst_disks => 0, :inst_disk_size =>  0,   :ephemeral_volumes => 0 },
     'm2.2xlarge'  => { :price => 0.90,  :bits => 64, :ram =>  35020, :cores => 4, :core_size => 3.25, :inst_disks => 2, :inst_disk_size =>  850, :ephemeral_volumes => 2 },
     'm2.4xlarge'  => { :price => 1.80,  :bits => 64, :ram =>  70041, :cores => 8, :core_size => 3.25, :inst_disks => 4, :inst_disk_size => 1690, :ephemeral_volumes => 4, :ebs_optimizable => 1000, },
     'cc1.4xlarge' => { :price => 1.30,  :bits => 64, :ram =>  23552, :cores => 8, :core_size => 4.19, :inst_disks => 4, :inst_disk_size => 1690, :ephemeral_volumes => 2, :placement_groupable => true, :virtualization => 'hvm' },


### PR DESCRIPTION
The newer m3 flavors were missing from the ec2_flavor_info in the ec2 dsl. 
