### PR TITLE
fix "undefined method" error when assigning elastic IPs

### DIFF
--- a/lib/ironfan/provider/ec2/elastic_ip.rb
+++ b/lib/ironfan/provider/ec2/elastic_ip.rb
@@ -58,7 +58,7 @@ module Ironfan
           return unless elastic_ip = computer.server.ec2.elastic_ip
           return unless recall? elastic_ip
           # also, in the case of VPC Elastic IPs, can discover and use allocation_id to attach a VPC Elastic IP.
-          return unless computer.server.ec2.include?(:elastic_ip)
+          return unless computer.server.ec2.methods.include?(:elastic_ip)
           if ( computer.server.ec2.elastic_ip.nil? and cloud.vpc.nil? )
             # First,  :elastic_ip is set, no address is currently allocated for this connection's owner
             # NOTE: We cannot specify an address to create, but after a reload we can then load the first available.


### PR DESCRIPTION
Ironfan versions later than 4.6.1 were not working when an elastic IP was defined in the cluster file. The IP would not be assigned and ironfan would produce this error:

ERROR: undefined method `include?' for #<Ironfan::Dsl::Ec2:0x9466b90> (NoMethodError)
/var/lib/gems/1.9.1/gems/ironfan-4.10.4/lib/ironfan/provider/ec2/elastic_ip.rb:62:in`save!'
