### PR TITLE
REALM discovery aids

### DIFF
--- a/lib/ironfan/dsl/cluster.rb
+++ b/lib/ironfan/dsl/cluster.rb
@@ -4,6 +4,8 @@ module Ironfan
     class Cluster < Ironfan::Dsl::Compute
       collection :facets,       Ironfan::Dsl::Facet,   :resolver => :deep_resolve
 
+      magic :clusters,          Whatever
+
       def initialize(attrs={},&block)
         super
         self.cluster_role       Ironfan::Dsl::Role.new(:name => "#{attrs[:name]}-cluster")

--- a/lib/ironfan/dsl/cluster.rb
+++ b/lib/ironfan/dsl/cluster.rb
@@ -4,11 +4,13 @@ module Ironfan
     class Cluster < Ironfan::Dsl::Compute
       collection :facets,       Ironfan::Dsl::Facet,   :resolver => :deep_resolve
 
-      magic :clusters,          Whatever
-
       def initialize(attrs={},&block)
         super
         self.cluster_role       Ironfan::Dsl::Role.new(:name => "#{attrs[:name]}-cluster")
+      end
+
+      def facet(name,attrs={},&block)
+        super(name,attrs.merge(cluster_names: cluster_names),&block)
       end
 
       # Utility method to reference all servers from constituent facets

--- a/lib/ironfan/dsl/compute.rb
+++ b/lib/ironfan/dsl/compute.rb
@@ -27,6 +27,8 @@ module Ironfan
       member     :cluster_role, Ironfan::Dsl::Role
       member     :facet_role,   Ironfan::Dsl::Role
 
+      magic      :cluster_names, Whatever
+
       def initialize(attrs={},&block)
         self.underlay   = attrs[:owner] if attrs[:owner]
         super

--- a/lib/ironfan/dsl/realm.rb
+++ b/lib/ironfan/dsl/realm.rb
@@ -9,14 +9,15 @@ module Ironfan
       end
 
       def cluster(label, attrs={},&blk)
-        new_name = [realm_name, label].join '_'
-        cluster = Ironfan::Dsl::Cluster.new(name: new_name)
+        new_name = [realm_name, label].join('_').to_sym
+        cluster = Ironfan::Dsl::Cluster.new(name: new_name, clusters: OpenStruct.new)
+        (clusters.keys.map{|k| clusters[k]}.to_a + [cluster]).
+          each{|cl| cl.clusters.new_ostruct_member label; cl.clusters.send "#{label}=", new_name}
         cluster.receive!(attrs, &blk)
         super(new_name, cluster)
       end
 
       def realm_name()        name;   end
     end
-
   end
 end

--- a/lib/ironfan/dsl/realm.rb
+++ b/lib/ironfan/dsl/realm.rb
@@ -4,16 +4,23 @@ module Ironfan
     class Realm < Ironfan::Dsl::Compute
       collection :clusters,       Ironfan::Dsl::Cluster,   :resolver => :deep_resolve
 
+      magic :cluster_suffixes,    Whatever
+
       def initialize(attrs={},&block)
+        cluster_names OpenStruct.new
+        cluster_suffixes OpenStruct.new
         super
       end
 
       def cluster(label, attrs={},&blk)
         new_name = [realm_name, label].join('_').to_sym
         cluster = Ironfan::Dsl::Cluster.new(name: new_name, cluster_names: OpenStruct.new)
+        cluster_names.new_ostruct_member label
+        cluster_names.send "#{label}=", new_name
+        cluster_suffixes.new_ostruct_member label
+        cluster_suffixes.send "#{label}=", label
         (clusters.keys.map{|k| clusters[k]} << cluster).each do |cl|
-          cl.cluster_names.new_ostruct_member label
-          cl.cluster_names.send "#{label}=", new_name
+          cl.cluster_names cluster_names
         end
         cluster.receive!(attrs, &blk)
         super(new_name, cluster)

--- a/lib/ironfan/dsl/realm.rb
+++ b/lib/ironfan/dsl/realm.rb
@@ -10,9 +10,11 @@ module Ironfan
 
       def cluster(label, attrs={},&blk)
         new_name = [realm_name, label].join('_').to_sym
-        cluster = Ironfan::Dsl::Cluster.new(name: new_name, clusters: OpenStruct.new)
-        (clusters.keys.map{|k| clusters[k]}.to_a + [cluster]).
-          each{|cl| cl.clusters.new_ostruct_member label; cl.clusters.send "#{label}=", new_name}
+        cluster = Ironfan::Dsl::Cluster.new(name: new_name, cluster_names: OpenStruct.new)
+        (clusters.keys.map{|k| clusters[k]} << cluster).each do |cl|
+          cl.cluster_names.new_ostruct_member label
+          cl.cluster_names.send "#{label}=", new_name
+        end
         cluster.receive!(attrs, &blk)
         super(new_name, cluster)
       end


### PR DESCRIPTION
I've added some a cluster_names field to aid clusters, facets, and components as they talk about clusters that have been created within a realm. It's easiest to explain with an example:

```
Ironfan.realm(:p1) do

  # declare control cluster.
  cluster(:control)

  cluster(:es) do
    zabbix_agent{ of cluster_names.control }
  end
end
```

In this case, cluster_names.control will be the symbol :p1_control, representing the name of the control cluster.
