### PR TITLE
REALM discovery aids cleanup

### DIFF
--- a/lib/ironfan/dsl/cluster.rb
+++ b/lib/ironfan/dsl/cluster.rb
@@ -7,10 +7,8 @@ module Ironfan
       def initialize(attrs={},&block)
         super
         self.cluster_role       Ironfan::Dsl::Role.new(:name => "#{attrs[:name]}-cluster")
-      end
-
-      def facet(name,attrs={},&block)
-        super(name,attrs.merge(cluster_names: cluster_names),&block)
+        self.realm_name         attrs[:owner].name unless attrs[:owner].nil?
+        self.cluster_names      attrs[:owner].cluster_names unless attrs[:owner].nil?
       end
 
       # Utility method to reference all servers from constituent facets
@@ -20,8 +18,9 @@ module Ironfan
         result
       end
 
-      def cluster_name()        name;   end
+      def cluster_name
+        name
+      end
     end
-
   end
 end

--- a/lib/ironfan/dsl/compute.rb
+++ b/lib/ironfan/dsl/compute.rb
@@ -28,6 +28,7 @@ module Ironfan
       member     :facet_role,   Ironfan::Dsl::Role
 
       magic      :cluster_names, Whatever
+      magic      :realm_name,    Symbol
 
       def initialize(attrs={},&block)
         self.underlay   = attrs[:owner] if attrs[:owner]

--- a/lib/ironfan/dsl/facet.rb
+++ b/lib/ironfan/dsl/facet.rb
@@ -7,7 +7,9 @@ module Ironfan
       field      :cluster_name, String
 
       def initialize(attrs={},&block)
-        self.cluster_name       = attrs[:owner].name unless attrs[:owner].nil?
+        self.cluster_names      attrs[:owner].cluster_names unless attrs[:owner].nil?
+        self.realm_name         attrs[:owner].realm_name unless attrs[:owner].nil?
+        self.cluster_name       = attrs[:owner].cluster_name unless attrs[:owner].nil?
         self.name               = attrs[:name] unless attrs[:name].nil?
         self.facet_role         Ironfan::Dsl::Role.new(:name => "#{full_name}-facet")
         super
@@ -15,8 +17,6 @@ module Ironfan
       end
 
       def full_name()           "#{cluster_name}-#{name}";      end
-
     end
-
   end
 end

--- a/lib/ironfan/dsl/realm.rb
+++ b/lib/ironfan/dsl/realm.rb
@@ -8,23 +8,27 @@ module Ironfan
 
       def initialize(attrs={},&block)
         cluster_names({})
-        cluster_suffixes({})
+        realm_name attrs[:name] if attrs[:name]
         super
       end
 
       def cluster(label, attrs={},&blk)
         new_name = [realm_name, label].join('_').to_sym
-        cluster = Ironfan::Dsl::Cluster.new(name: new_name, cluster_names: {})
+        cluster = Ironfan::Dsl::Cluster.new(name: new_name, owner: self, cluster_names: cluster_names)
         cluster_names[label] = new_name
-        cluster_suffixes[label] = label
-        (clusters.keys.map{|k| clusters[k]} << cluster).each do |cl|
-          cl.cluster_names cluster_names
-        end
         cluster.receive!(attrs, &blk)
         super(new_name, cluster)
       end
 
-      def realm_name()        name;   end
+      def cluster_name suffix
+        clusters.fetch([realm_name, suffix.to_s].join('_').to_sym).name.to_sym
+      end
+      
+      def cluster_suffix suffix
+        clusters.
+          fetch([realm_name, suffix.to_s].join('_').to_sym).name.to_s.
+          gsub(/^#{realm_name}_/, '').to_sym
+      end
     end
   end
 end

--- a/lib/ironfan/dsl/realm.rb
+++ b/lib/ironfan/dsl/realm.rb
@@ -7,18 +7,16 @@ module Ironfan
       magic :cluster_suffixes,    Whatever
 
       def initialize(attrs={},&block)
-        cluster_names OpenStruct.new
-        cluster_suffixes OpenStruct.new
+        cluster_names({})
+        cluster_suffixes({})
         super
       end
 
       def cluster(label, attrs={},&blk)
         new_name = [realm_name, label].join('_').to_sym
-        cluster = Ironfan::Dsl::Cluster.new(name: new_name, cluster_names: OpenStruct.new)
-        cluster_names.new_ostruct_member label
-        cluster_names.send "#{label}=", new_name
-        cluster_suffixes.new_ostruct_member label
-        cluster_suffixes.send "#{label}=", label
+        cluster = Ironfan::Dsl::Cluster.new(name: new_name, cluster_names: {})
+        cluster_names[label] = new_name
+        cluster_suffixes[label] = label
         (clusters.keys.map{|k| clusters[k]} << cluster).each do |cl|
           cl.cluster_names cluster_names
         end


### PR DESCRIPTION
Realms now have access to a cluster_suffix helper that can be used as
follows.

```
Ironfan.realm(:p1) do
  # declaration
  cluster(:control)

  # implementation
  cluster(cluster_suffix(:control)) do
    # ...
  end
end
```

cluster_suffix(suffix) always returns suffix: it is the identity
function with a twist. The twist is that it will ensure that the
cluster exists within the realm. This is to ward off typos.

In addition, components now have access to a cluster_name helper that
can be used as follows.

```
Ironfan.realm(:p1) do
  # declaration
  cluster(:control)

  # implementation
  cluster(cluster_prefix(:control)) do
    facet(:nfs) do
      # ...
      nfs_server
      # ...
    end

    facet(:zabbix) do
      # ...
      nfs_client{ of cluster_name(:control) }
      # ...
    end
  end
end
```

In this case, in addition to ensuring that the :control cluster exists
within this realm, cluster_name(:control) returns the full name of the
cluster: :p1_control.

I've discovered that this style is preferable to using method calls (e.g., cluster_name.control).

These changes also contain fixes that allow cloud settings for realms to be correctly resolved into their clusters!
