### PR TITLE
Passing --pid_file PID_FILE, --log_file LOG_FILE to knife cluster kick d...

### DIFF
--- a/lib/chef/knife/cluster_kick.rb
+++ b/lib/chef/knife/cluster_kick.rb
@@ -38,12 +38,12 @@ class Chef
       banner 'knife cluster kick        CLUSTER[-FACET[-INDEXES]] (options) - start a run of chef-client on each server, tailing the logs and exiting when the run completes.'
 
       option :pid_file,
-        :long        => "--pid_file",
+        :long        => "--pid_file PID_FILE",
         :description => "Where to find the pid file. Typically /var/run/chef/client.pid (init.d) or /etc/sv/chef-client/supervise/pid (runit)",
         :default     => "/etc/sv/chef-client/supervise/pid"
 
       option :log_file,
-        :long        => "--log_file",
+        :long        => "--log_file LOG_FILE",
         :description => "Where to find the log file. Typically /var/log/chef/client.log",
         :default     => "/var/log/chef/client.log"
 


### PR DESCRIPTION
...oes not work (e.g. PID_FILE is treated as facet name).
