### PR TITLE
add ironfan components and plugins, bump to 5.0.0

### DIFF
--- a/ironfan.gemspec
+++ b/ironfan.gemspec
@@ -5,11 +5,11 @@
 
 Gem::Specification.new do |s|
   s.name = "ironfan"
-  s.version = "4.12.3"
+  s.version = "5.0.0"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Infochimps"]
-  s.date = "2013-10-10"
+  s.date = "2013-12-11"
   s.description = "Ironfan allows you to orchestrate not just systems but clusters of machines. It includes a powerful layer on top of knife and a collection of cloud cookbooks."
   s.email = "coders@infochimps.com"
   s.extra_rdoc_files = [
@@ -67,6 +67,7 @@ Gem::Specification.new do |s|
     "lib/ironfan/dsl.rb",
     "lib/ironfan/dsl/cloud.rb",
     "lib/ironfan/dsl/cluster.rb",
+    "lib/ironfan/dsl/component.rb",
     "lib/ironfan/dsl/compute.rb",
     "lib/ironfan/dsl/ec2.rb",
     "lib/ironfan/dsl/facet.rb",
@@ -78,6 +79,7 @@ Gem::Specification.new do |s|
     "lib/ironfan/dsl/volume.rb",
     "lib/ironfan/dsl/vsphere.rb",
     "lib/ironfan/headers.rb",
+    "lib/ironfan/plugin/base.rb",
     "lib/ironfan/provider.rb",
     "lib/ironfan/provider/chef.rb",
     "lib/ironfan/provider/chef/client.rb",

--- a/lib/ironfan/dsl/cluster.rb
+++ b/lib/ironfan/dsl/cluster.rb
@@ -3,6 +3,11 @@ module Ironfan
 
     class Cluster < Ironfan::Dsl::Compute
       collection :facets,       Ironfan::Dsl::Facet,   :resolver => :deep_resolve
+      include Ironfan::Plugin::Base; register_with Ironfan::Dsl::Realm
+
+      def children
+        facets.to_a + components.to_a
+      end
 
       def initialize(attrs={},&block)
         super
@@ -20,6 +25,11 @@ module Ironfan
 
       def cluster_name
         name
+      end
+
+      def self.plugin_hook owner, attrs, plugin_name, full_name, &blk
+        owner.cluster(plugin_name, new(attrs.merge(name: full_name, owner: owner)))
+        _project cluster, &blk
       end
     end
   end

--- a/lib/ironfan/dsl/component.rb
+++ b/lib/ironfan/dsl/component.rb
@@ -1,0 +1,157 @@
+module Ironfan
+  class Dsl
+    class Component < Ironfan::Dsl
+      include Gorillib::Builder
+      include Gorillib::Concern
+      include Ironfan::Plugin::Base; register_with Ironfan::Dsl::Compute
+
+      field :cluster_name, Symbol
+      field :facet_name, Symbol
+      field :realm_name, Symbol
+      field :name, Symbol
+
+      def initialize(attrs, &blk)
+        attrs.merge!(facet_name: (attrs[:owner].name unless attrs[:owner].nil? or not attrs[:owner].is_a?(Facet)),
+                     cluster_name: (attrs[:owner].cluster_name unless attrs[:owner].nil?),
+                     realm_name: (attrs[:owner].realm_name unless attrs[:owner].nil?))
+        super attrs, &blk
+      end
+
+      def self.plugin_hook owner, attrs, plugin_name, full_name, &blk
+        (this = new(attrs.merge(owner: owner, name: full_name), &blk))._project(owner)
+        this
+      end
+
+      def announce_to node
+        node.set['components']["#{cluster_name}-#{name}"]['name'] = name
+      end
+
+      def self.to_node
+        super.tap do |node|
+          node.set['cluster_name'] = cluster_name
+        end
+      end
+
+      def self.from_node(node = NilCheckDelegate.new(nil))
+        cluster_name = node['cluster_name'].to_s
+        super(node).tap{|x| x.receive!(cluster_name: cluster_name,
+                                       realm_name: cluster_name.split('_').first)}
+      end
+
+      def self.announce_name
+        plugin_name
+      end
+
+      def announce_name
+        self.class.announce_name
+      end
+
+      def _project(compute)
+        compute.component name, self
+        project(compute)
+      end
+
+      def realm_announcements
+        (@@realm_announcements ||= {})
+      end
+      
+      def realm_subscriptions component_name
+        (@@realm_subscriptions ||= {})[component_name] ||= []
+      end
+
+      def announce(component_name)
+        Chef::Log.debug("announced #{announce_name} for #{cluster_name}")
+        realm_announcements[[realm_name, component_name]] = [cluster_name, facet_name]
+        realm_subscriptions(component_name).each{|blk| blk.call(cluster_name, facet_name)}
+      end
+
+      def discover(component_name, &blk)
+        if already_announced = realm_announcements[[realm_name, component_name]]
+          yield *already_announced
+        else
+          Chef::Log.debug("#{cluster_name}: no one announced #{announce_name}. subscribing")
+          realm_subscriptions(component_name) << blk
+        end
+      end
+    end
+
+    module Discovery
+      include Gorillib::Builder
+      extend Gorillib::Concern
+
+      magic :server_cluster, Symbol
+      magic :bidirectional, :boolean, default: false
+
+      (@_dependencies ||= []) << Gorillib::Builder
+
+      module ClassMethods
+        def default_to_bidirectional default=true
+          fields[:bidirectional].default = default
+        end
+      end
+
+      def set_discovery compute, keys
+        if server_cluster
+          wire_to(compute, full_server_cluster, facet_name, keys)
+        else
+          discover(announce_name) do |cluster_name, facet_name|
+            wire_to(compute, cluster_name, facet_name, keys)
+          end
+        end
+      end
+
+      def wire_to(compute, cluster_name, facet_name, keys)
+        discovery = {discovers: keys.reverse.inject(cluster_name){|hsh,key| {key => hsh}}}
+        (compute.facet_role || compute.cluster_role).override_attributes(discovery)
+
+        # FIXME: This is Ec2-specific and probably doesn't belong here.
+        client_group_v = client_group(compute)
+        server_group_v = server_group(cluster_name, facet_name)
+        
+        group_edge(compute.cloud(:ec2), client_group_v, server_group_v)
+        group_edge(compute.cloud(:ec2), server_group_v, client_group_v) if bidirectional
+
+        Chef::Log.debug("discovered #{announce_name} for #{cluster_name}: #{discovery}")
+      end
+
+      protected
+
+      def client_group(compute)
+        security_group(compute.cluster_name, (compute.name if compute.is_a?(Facet)))
+      end
+      
+      def full_server_cluster
+        "#{realm_name}_#{server_cluster}"
+      end
+
+      def group_edge(cloud, group_1, group_2)
+        cloud.security_group(group_1).authorize_group(group_2)
+        Chef::Log.debug("component.rb: allowing access from security group #{group_1} to #{group_2}")
+      end
+
+      def security_group(cluster_name, facet_name)
+        facet_name ? [cluster_name, facet_name].join('-') : cluster_name
+      end
+
+      def server_group(cluster_name, facet_name)
+        security_group(cluster_name, facet_name)
+      end
+    end
+
+    module Announcement
+      include Gorillib::Builder
+
+      def _project(compute)
+        announce announce_name
+        super compute
+      end
+    end
+    def to_manifest
+      to_wire.reject{|k,_| _skip_fields.include? k}
+    end
+
+    def _skip_fields() skip_fields << :_type; end
+
+    def skip_fields() [] end
+  end
+end

--- a/lib/ironfan/dsl/compute.rb
+++ b/lib/ironfan/dsl/compute.rb
@@ -1,3 +1,5 @@
+require 'gorillib/metaprogramming/concern'
+
 module Ironfan
   class Dsl
 
@@ -16,6 +18,7 @@ module Ironfan
       field      :name,         String
 
       # Resolve each of the following as a merge of their container's attributes and theirs
+      collection :components,   Ironfan::Dsl::Component,   :resolver => :merge_resolve, :key_method => :name
       collection :run_list_items, RunListItem,             :resolver => :merge_resolve, :key_method => :name
       collection :clouds,       Ironfan::Dsl::Cloud,       :resolver => :merge_resolve, :key_method => :name
       collection :volumes,      Ironfan::Dsl::Volume,      :resolver => :merge_resolve, :key_method => :name
@@ -29,6 +32,14 @@ module Ironfan
 
       magic      :cluster_names, Whatever
       magic      :realm_name,    Symbol
+
+      field      :source_file,   String
+
+      extend Gorillib::Concern
+
+      def self._project compute, &blk
+        compute.around &blk
+      end
 
       def initialize(attrs={},&block)
         self.underlay   = attrs[:owner] if attrs[:owner]
@@ -89,8 +100,18 @@ module Ironfan
         raise "run_list placement must be one of :first, :normal, :last or nil (also means :normal)" unless [:first, :last, :own, nil].include?(placement)
         placement = :normal if placement.nil?
         @@run_list_rank += 1
+        # Rank is a global order that tells what order this was encountered in. 
         run_list_items[item] = { :name => item, :rank => @@run_list_rank, :placement => placement }
       end
+
+      def around &blk
+        before
+        instance_eval(&blk)
+        after
+      end
+
+      def after() end
+      def before() end
     end
 
   end

--- a/lib/ironfan/dsl/facet.rb
+++ b/lib/ironfan/dsl/facet.rb
@@ -2,6 +2,8 @@ module Ironfan
   class Dsl
 
     class Facet < Ironfan::Dsl::Compute
+      include Ironfan::Plugin::Base; register_with Ironfan::Dsl::Cluster
+
       magic      :instances,    Integer,                :default => 1
       collection :servers,      Ironfan::Dsl::Server,   :resolver => :deep_resolve
       field      :cluster_name, String
@@ -16,7 +18,16 @@ module Ironfan
         for i in 0 .. instances-1; server(i); end
       end
 
+      def children
+        servers.to_a + components.to_a
+      end
+
       def full_name()           "#{cluster_name}-#{name}";      end
+
+      def self.plugin_hook owner, attrs, plugin_name, full_name, &blk
+        facet = owner.facet(plugin_name, new(attrs.merge(name: plugin_name, owner: owner)))
+        _project facet, &blk
+      end
     end
   end
 end

--- a/lib/ironfan/dsl/realm.rb
+++ b/lib/ironfan/dsl/realm.rb
@@ -4,30 +4,33 @@ module Ironfan
     class Realm < Ironfan::Dsl::Compute
       collection :clusters,       Ironfan::Dsl::Cluster,   :resolver => :deep_resolve
 
+      def children
+        clusters.to_a
+      end
+
       magic :cluster_suffixes,    Whatever
 
       def initialize(attrs={},&block)
         cluster_names({})
         realm_name attrs[:name] if attrs[:name]
-        super
+        attrs[:environment] = realm_name unless attrs.has_key?(:environment)
+        super(attrs, &block)
       end
 
       def cluster(label, attrs={},&blk)
         new_name = [realm_name, label].join('_').to_sym
-        cluster = Ironfan::Dsl::Cluster.new(name: new_name, owner: self, cluster_names: cluster_names)
-        cluster_names[label] = new_name
-        cluster.receive!(attrs, &blk)
-        super(new_name, cluster)
-      end
 
-      def cluster_name suffix
-        clusters.fetch([realm_name, suffix.to_s].join('_').to_sym).name.to_sym
-      end
-      
-      def cluster_suffix suffix
-        clusters.
-          fetch([realm_name, suffix.to_s].join('_').to_sym).name.to_s.
-          gsub(/^#{realm_name}_/, '').to_sym
+        if clusters.keys.include? new_name
+          clusters[new_name].tap do |cl|
+            cl.receive!(attrs)
+            cl.instance_eval(&blk) if block_given?
+          end
+        else
+          cluster = Ironfan::Dsl::Cluster.new(name: new_name, owner: self, cluster_names: cluster_names)
+          cluster_names[label] = new_name
+          cluster.receive!(attrs, &blk)
+          super(new_name, cluster)
+        end
       end
     end
   end

--- a/lib/ironfan/headers.rb
+++ b/lib/ironfan/headers.rb
@@ -15,9 +15,11 @@ module Ironfan
   end
 
   class Dsl < Builder
+    class Component < Ironfan::Dsl; end
     class Compute < Ironfan::Dsl; end
     class Cluster < Ironfan::Dsl::Compute; end
     class Facet < Ironfan::Dsl::Compute; end
+    class Realm < Ironfan::Dsl::Compute; end
     class Server < Ironfan::Dsl::Compute; end
 
     class Role < Ironfan::Dsl; end
@@ -34,6 +36,11 @@ module Ironfan
     class Rds < Cloud
       class SecurityGroup < Ironfan::Dsl; end
     end
+  end
+
+  module Plugin
+    class CookbookRequirement; end
+    module Base; end
   end
 
   class Provider < Builder

--- a/lib/ironfan/plugin/base.rb
+++ b/lib/ironfan/plugin/base.rb
@@ -1,0 +1,89 @@
+require 'gorillib/model'
+require 'gorillib/builder'
+require 'gorillib/string/inflections'
+require 'gorillib/metaprogramming/concern'
+
+Gorillib::Model::Field.class_eval do
+  field :node_attr, String, default: nil
+end
+
+module Ironfan
+
+  module Pluggable
+    def add_plugin name, cls
+      registry[name] = cls
+    end
+    def plugin_for name
+      registry[name]
+    end
+    def registry() @registry ||= {}; end
+  end
+
+  module Plugin
+    class CookbookRequirement
+      include Gorillib::Builder
+
+      magic :name, String
+      magic :constraint, String
+
+      def <=>(other)
+        self.name <=> other.name
+      end
+    end
+
+    module Base
+      extend Gorillib::Concern
+
+      def to_node
+        Chef::Node.new.tap do |node|
+          self.class.fields.select{|_,x| x.node_attr}.each do |_,x|
+            val = send(x.name)
+            (keys = x.node_attr.split('.'))[0...-1].inject(node.set) do |hsh,key|
+              hsh[key]
+            end[keys.last] = val unless val.nil?
+          end
+        end
+      end
+
+      module ClassMethods
+        attr_reader :cookbook_reqs
+        attr_reader :plugin_name
+
+        def from_node(node = NilCheckDelegate.new(nil))
+          new(Hash[
+                   fields.select{|_,x| x.node_attr}.map do |_,x|
+                     [x.name, (x.node_attr.split('.').inject(node) do |hsh,attr|
+                                 if hsh
+                                   (val = hsh[attr]).is_a?(Mash) ? val.to_hash : val
+                                 end
+                               end)]
+                   end.reject{|_,v| v.nil?}
+                  ])
+        end
+
+        def register_with cls, &blk
+          (@dest_class = cls).class_eval{ extend Ironfan::Pluggable }
+        end
+
+        def template plugin_name_parts, base_class=self, &blk
+          plugin_name_parts = [*plugin_name_parts]
+          full_name = plugin_name_parts.map(&:to_s).join('_').to_sym
+          plugin_name = plugin_name_parts.first.to_sym
+
+          Class.new(base_class, &blk).tap do |plugin_class|
+            plugin_class.class_eval{ @plugin_name = plugin_name }
+
+            self.const_set(full_name.to_s.camelize.to_sym, plugin_class)
+
+            @dest_class.class_eval do
+              add_plugin(full_name, plugin_class)
+              define_method(full_name) do |*args, &blk|
+                plugin_class.plugin_hook self, (args.first || {}), plugin_name, full_name, &blk
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ironfan/requirements.rb
+++ b/lib/ironfan/requirements.rb
@@ -5,10 +5,14 @@ require 'gorillib/resolution'
 # Pre-declaration of class hierarchy
 require 'ironfan/headers'
 
+# Ironfan plugin mixin
+require 'ironfan/plugin/base'
+
 # DSL for cluster descriptions
 require 'ironfan/dsl'
 require 'ironfan/builder'
 
+require 'ironfan/dsl/component'
 require 'ironfan/dsl/compute'
 require 'ironfan/dsl/server'
 require 'ironfan/dsl/facet'

--- a/spec/ironfan/plugin_spec.rb
+++ b/spec/ironfan/plugin_spec.rb
@@ -1,0 +1,138 @@
+require_relative '../spec_helper.rb'
+
+describe MyPlugin do
+  subject { MyPlugin }
+
+  it 'should respond to template' do
+    subject.should(respond_to(:template))
+  end
+
+  context 'when templatizing plugins' do
+    after(:each) do
+      uncreate_plugin(subject, Foo)
+    end
+    before(:each) do
+      subject.template(%w[baz bif])
+    end
+
+    it 'should create them as classes within itself' do
+      subject.constants.should(include(:BazBif))
+    end
+    it 'should create them as subclasses of itself' do
+      subject.const_get(:BazBif).should(be < subject)
+    end
+    it 'should allow customizing the classes' do
+      uncreate_plugin(subject, Foo)
+      subject.template(%w[baz bif]){ def bam() end }
+      subject.const_get(:BazBif).new.should(respond_to(:bam))
+    end
+    it 'should register methods on the specified class' do
+      Foo.new.should(respond_to(:baz_bif))
+    end
+    it 'should wire those methods to the plugin_hook method of itself' do
+      foo = Foo.new
+      subject.should_receive(:plugin_hook).with(foo, {}, :baz, :baz_bif)
+      foo.baz_bif
+    end
+    it 'should allow the user to create a custom class that will also be registered' do
+      Foo.registry[:baz_bif].should(be(subject.const_get(:BazBif)))
+    end
+  end
+end
+
+describe Ironfan::Dsl::Component do
+  before(:each) do
+    Ironfan::Dsl::Component.template(%w[baz bif]) do
+      include Ironfan::Dsl::Component::Announcement
+
+      magic :bam, Symbol, node_attr: 'a.b.c', default: nil
+
+      def project(compute)
+        compute.role(:called_from_project, compute) unless bam
+      end
+    end
+  end
+
+  after(:each) do
+    uncreate_plugin(Ironfan::Dsl::Component, Ironfan::Dsl::Compute)
+  end
+
+  it 'should have its project method called by the plugin_hook' do
+    Ironfan.cluster(:foo) do
+      should_receive(:role).with(:called_from_project, self)
+      baz_bif
+    end
+  end
+
+  it 'should merge its node attribute to create a node' do
+    node = Chef::Node.new
+    node.set['a'] = {'b' => {'c' => :baz}}
+    Ironfan.cluster(:foo) do
+      baz_bif{ bam(:baz) }.to_node.to_hash.should == node.to_hash
+    end
+  end
+  it 'should be instantiable from a node object' do
+    node = Chef::Node.new
+    node.set['a'] = {'b' => {'c' => :baz}}
+    Ironfan::Dsl::Compute.registry[:baz_bif].from_node(node).bam.should == :baz
+  end
+
+  it 'should remember all of its node attributes' do
+    Ironfan.cluster(:foo) do
+      component = baz_bif{ bam(:baz) }
+      component.to_node.to_hash.should ==
+        Ironfan::Dsl::Compute.registry[:baz_bif].from_node(component.to_node).to_node.to_hash
+    end
+  end
+
+  context 'when announcing' do
+    before (:each) do
+      def make_plugin(name, server_b)
+        Ironfan::Dsl::Component.template([name, server_b ? 'server' : 'client']) do
+          include Ironfan::Dsl::Component::Announcement if server_b
+          include Ironfan::Dsl::Component::Discovery    if not server_b
+
+          if server_b
+            def project(compute)
+            end
+          else
+            def project(compute)
+              set_discovery compute, [announce_name]
+            end
+          end
+        end
+      end
+
+      def make_plugin_pair(name) make_plugin(name, true); make_plugin(name, false); end
+
+      make_plugin_pair(:bam); make_plugin_pair(:pow)
+    end
+
+    it 'automatically discovers announcements within realms' do
+      Ironfan.realm(:wap) do
+        cluster(:foo){ bam_client; pow_server }
+        cluster(:bar){ bam_server; pow_client }
+
+        cluster(:foo).cluster_role.override_attributes[:discovers].should == {bam: :wap_bar}
+        cluster(:bar).cluster_role.override_attributes[:discovers].should == {pow: :wap_foo}
+      end
+    end
+
+    it 'automatically configures security groups during discovery' do
+      Ironfan.realm(:wap) do
+        cloud(:ec2)
+
+        cluster(:foo){ bam_client; pow_server }
+        cluster(:bar){ bam_server; pow_client }
+      end.resolve!
+
+      rspec = self
+
+      foo_group = Ironfan.realm(:wap).cluster(:foo).cloud(:ec2).security_group('wap_foo')
+      bar_group = Ironfan.realm(:wap).cluster(:bar).cloud(:ec2).security_group('wap_bar')
+
+      foo_group.group_authorized.should include('wap_bar')
+      bar_group.group_authorized.should include('wap_foo')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 $:.unshift File.expand_path('../../lib', __FILE__)
 require 'chef'
 require 'chef/knife'
+require 'ironfan'
 require 'fog'
 Fog.mock!
 Fog::Mock.delay = 0
@@ -36,3 +37,17 @@ end
 require 'chef_zero/server'
 server = ChefZero::Server.new(port: 4000)
 server.start_background
+
+def uncreate_plugin(plugin_class, target_class)
+  target_class.registry.clear
+  plugin_class.instance_eval{ remove_const :BazBif }
+end
+
+class Foo
+end
+
+class MyPlugin
+  include Ironfan::Plugin::Base; register_with Foo
+
+  def self.plugin_hook(*_) end
+end


### PR DESCRIPTION
Ironfan components provide functionality similar to Chef roles: they
provide a way to group recipes and attributes. Unlike roles, they live
entirely on the client side and can be parameterized. The following
example creates an nfs server component and then uses it in a cluster
definition. Note that components are Gorillib Builders, which allows
the 'foo' parameter to be passed in in this case.

```
Ironfan::Plugin::Component.create(%w[nfs server]) do
  magic :foo, String

  def project(compute)
    compute.instances(1)
    compute.cloud(:ec2).security_group(:nfs_server).authorize_group :systemwide

Chef::Log.info("was passed #{foo} by the cluster")

    compute.recipe 'nfs'
    compute.recipe 'nfs::server'
  end
end

Ironfan.cluster(:nfs) do
  facet(:server) do
    nfs_server{ foo 'foo string' }
  end
end
```
