### PR TITLE
[aws] [elb] Handle pagination when there are over 100 IAM Certificates

### DIFF
--- a/lib/ironfan/provider/ec2/iam_server_certificate.rb
+++ b/lib/ironfan/provider/ec2/iam_server_certificate.rb
@@ -27,10 +27,19 @@ module Ironfan
         # Discovery
         #
         def self.load!(cluster=nil)
-          Ec2.iam.list_server_certificates.body['Certificates'].each do |cert|
-            iss = new(:adaptee => cert)
-            remember(iss, { :id => cert['ServerCertificateName'] })
-            remember(iss, { :id => "#{ARN_PREFIX}:#{cert['Arn']}" })
+          opts = {}
+          while true do
+            res = Ec2.iam.list_server_certificates(opts)
+            res.body['Certificates'].each do |cert|
+              iss = new(:adaptee => cert)
+              remember(iss, { :id => cert['ServerCertificateName'] })
+              remember(iss, { :id => "#{ARN_PREFIX}:#{cert['Arn']}" })
+            end
+            if res.body['Marker']
+              opts['Marker'] = res.body['Marker']
+            else
+              break
+            end
           end
         end
 


### PR DESCRIPTION
In the situation where you have over 100 SSL Certificates in your AWS account, Ironfan was only seeing the first 100.  This fix implements pagination on the certificate list.
